### PR TITLE
Inject sentry release information at runtime not build time

### DIFF
--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -220,7 +220,7 @@ export class Initializer {
             Sentry.reactRouterV5BrowserTracingIntegration({ history }),
           ],
           tracesSampleRate: 1.0,
-          release: process.env.VITE_APP_VERSION,
+          release: import.meta.env.VITE_APP_VERSION,
         });
       }
       // Sentry is now 'loadeed' (even if we actually skipped starting

--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -220,6 +220,7 @@ export class Initializer {
             Sentry.reactRouterV5BrowserTracingIntegration({ history }),
           ],
           tracesSampleRate: 1.0,
+          release: process.env.VITE_APP_VERSION,
         });
       }
       // Sentry is now 'loadeed' (even if we actually skipped starting

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,10 @@ export default defineConfig(({ mode }) => {
       sentryVitePlugin({
         release: {
           name: process.env.VITE_APP_VERSION,
+          // We don't inject the release info at build time because it has a side effect of
+          // changing the asset hashes each time meaning that it breaks browser caching.
+          // Instead we pass it in at runtime via Sentry.init().
+          inject: false,
         },
       }),
     );


### PR DESCRIPTION
See https://github.com/element-hq/element-call/issues/2871 for context of impact.