### PR TITLE
Don't produce compressed assets at build time and instead do it as part of the nginx build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
+FROM alpine AS builder
+
+COPY ./dist /dist
+
+# Compress assets to work with nginx-gzip-static-module
+WORKDIR /dist/assets
+RUN gzip -k ../index.html *.js *.map *.css *.wasm *-app-*.json 
+
 FROM nginxinc/nginx-unprivileged:alpine
 
-COPY ./dist /app
+COPY --from=builder ./dist /app
+
 COPY config/nginx.conf /etc/nginx/conf.d/default.conf

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "unique-names-generator": "^4.6.0",
     "vaul": "^1.0.0",
     "vite": "^6.0.0",
-    "vite-plugin-compression2": "^1.3.1",
     "vite-plugin-html-template": "^1.1.0",
     "vite-plugin-svgr": "^4.0.0",
     "vitest": "^3.0.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,6 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { defineConfig, loadEnv } from "vite";
-import { compression } from "vite-plugin-compression2";
 import svgrPlugin from "vite-plugin-svgr";
 import htmlTemplate from "vite-plugin-html-template";
 import { codecovVitePlugin } from "@codecov/vite-plugin";
@@ -38,10 +37,6 @@ export default defineConfig(({ mode }) => {
       enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
       bundleName: "element-call",
       uploadToken: process.env.CODECOV_TOKEN,
-    }),
-
-    compression({
-      exclude: [/config.json/],
     }),
   ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,7 +2519,7 @@
     "@react-spring/shared" "~9.7.5"
     "@react-spring/types" "~9.7.5"
 
-"@rollup/pluginutils@^5.1.0", "@rollup/pluginutils@^5.1.3":
+"@rollup/pluginutils@^5.1.3":
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.3.tgz#3001bf1a03f3ad24457591f2c259c8e514e0dbdf"
   integrity sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==
@@ -8133,11 +8133,6 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-mini@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/tar-mini/-/tar-mini-0.2.0.tgz#2b2cdc215f5b83b0ab8ce363dc9ded22de51849b"
-  integrity sha512-+qfUHz700DWnRutdUsxRRVZ38G1Qr27OetwaMYTdg8hcPxf46U0S1Zf76dQMWRBmusOt2ZCK5kbIaiLkoGO7WQ==
-
 teex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/teex/-/teex-1.0.1.tgz#b8fa7245ef8e8effa8078281946c85ab780a0b12"
@@ -8627,14 +8622,6 @@ vite-node@3.0.5:
     es-module-lexer "^1.6.0"
     pathe "^2.0.2"
     vite "^5.0.0 || ^6.0.0"
-
-vite-plugin-compression2@^1.3.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/vite-plugin-compression2/-/vite-plugin-compression2-1.3.3.tgz#d33ddfb4000c914783f4760f81a44ba52fc21ed1"
-  integrity sha512-Mb+xi/C5b68awtF4fNwRBPtoZiyUHU3I0SaBOAGlerlR31kusq1si6qG31lsjJH8T7QNg/p3IJY2HY9O9SvsfQ==
-  dependencies:
-    "@rollup/pluginutils" "^5.1.0"
-    tar-mini "^0.2.0"
 
 vite-plugin-html-template@^1.1.0:
   version "1.2.2"


### PR DESCRIPTION
The core vite build shouldn't be responsible for implementing optimisations that are specific to a particular distribution mechanism. e.g. static compressed files for nginx.

This way the core build is "clean".

Instead, the packager/distributor of the build should be responsible for it. e.g. the nginx docker distribution should do any optimisations that it chooses.

Part of https://github.com/element-hq/element-call/issues/2994