### PR TITLE
Show current SFU and Server Info in developer tab

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -66,8 +66,8 @@
     "device_id": "Device ID: {{id}}",
     "duplicate_tiles_label": "Number of additional tile copies per participant",
     "hostname": "Hostname: {{hostname}}",
-    "livekit_sfu": "LiveKit SFU: {{url}}",
     "livekit_server_info": "LiveKit Server Info",
+    "livekit_sfu": "LiveKit SFU: {{url}}",
     "matrix_id": "Matrix ID: {{id}}",
     "show_connection_stats": "Show connection statistics",
     "show_non_member_tiles": "Show tiles for non-member media"

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -66,6 +66,8 @@
     "device_id": "Device ID: {{id}}",
     "duplicate_tiles_label": "Number of additional tile copies per participant",
     "hostname": "Hostname: {{hostname}}",
+    "livekit_sfu": "LiveKit SFU: {{url}}",
+    "livekit_server_info": "LiveKit Server Info",
     "matrix_id": "Matrix ID: {{id}}",
     "show_connection_stats": "Show connection statistics",
     "show_non_member_tiles": "Show tiles for non-member media"

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -679,6 +679,7 @@ export const InCallView: FC<InCallViewProps> = ({
             onDismiss={closeSettings}
             tab={settingsTab}
             onTabChange={setSettingsTab}
+            livekitRoom={livekitRoom}
           />
         </>
       )}

--- a/src/settings/DeveloperSettingsTab.module.css
+++ b/src/settings/DeveloperSettingsTab.module.css
@@ -1,0 +1,10 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only
+Please see LICENSE in the repository root for full details.
+*/
+
+pre {
+  font-size: var(--font-size-micro);
+}

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -29,6 +29,7 @@ import { PreferencesSettingsTab } from "./PreferencesSettingsTab";
 import { Slider } from "../Slider";
 import { DeviceSelection } from "./DeviceSelection";
 import { DeveloperSettingsTab } from "./DeveloperSettingsTab";
+import { Room as LivekitRoom } from "livekit-client";
 
 type SettingsTab =
   | "audio"
@@ -46,6 +47,7 @@ interface Props {
   onTabChange: (tab: SettingsTab) => void;
   client: MatrixClient;
   roomId?: string;
+  livekitRoom?: LivekitRoom;
 }
 
 export const defaultSettingsTab: SettingsTab = "audio";
@@ -57,6 +59,7 @@ export const SettingsModal: FC<Props> = ({
   onTabChange,
   client,
   roomId,
+  livekitRoom,
 }) => {
   const { t } = useTranslation();
 
@@ -138,7 +141,7 @@ export const SettingsModal: FC<Props> = ({
   const developerTab: Tab<SettingsTab> = {
     key: "developer",
     name: t("settings.developer_tab_title"),
-    content: <DeveloperSettingsTab client={client} />,
+    content: <DeveloperSettingsTab client={client} livekitRoom={livekitRoom} />,
   };
 
   const tabs = [audioTab, videoTab];

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -9,6 +9,7 @@ import { type FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 import { Root as Form } from "@vector-im/compound-web";
+import { type Room as LivekitRoom } from "livekit-client";
 
 import { Modal } from "../Modal";
 import styles from "./SettingsModal.module.css";
@@ -29,7 +30,6 @@ import { PreferencesSettingsTab } from "./PreferencesSettingsTab";
 import { Slider } from "../Slider";
 import { DeviceSelection } from "./DeviceSelection";
 import { DeveloperSettingsTab } from "./DeveloperSettingsTab";
-import { Room as LivekitRoom } from "livekit-client";
 
 type SettingsTab =
   | "audio"


### PR DESCRIPTION
This PR exposes some info on the LiveKit SFU for diagnostic purposes:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/66203f9a-9fd6-462b-957c-42cff9e588dc" />

It only shows once you are joined to a call.