### PR TITLE
Refactor to simplify data flow from Matrix event listeners into call view logic

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -40,6 +40,7 @@ import {
   of,
   race,
   scan,
+  share,
   skip,
   startWith,
   switchAll,
@@ -464,6 +465,16 @@ export class CallViewModel extends ViewModel {
       },
     );
 
+  private readonly membershipsChanged$ = fromEvent(
+    this.matrixRTCSession,
+    MatrixRTCSessionEvent.MembershipsChanged,
+  ).pipe(share());
+
+  private readonly roomMembers$ = fromEvent(
+    this.matrixRTCSession.room,
+    RoomStateEvent.Members,
+  ).pipe(share());
+
   /**
    * Displaynames for each member of the call. This will disambiguate
    * any displaynames that clashes with another member. Only members
@@ -471,9 +482,9 @@ export class CallViewModel extends ViewModel {
    */
   public readonly memberDisplaynames$ = merge(
     // Handle call membership changes.
-    fromEvent(this.matrixRTCSession, MatrixRTCSessionEvent.MembershipsChanged),
+    this.membershipsChanged$,
     // Handle room membership changes (and displayname updates)
-    fromEvent(this.matrixRTCSession.room, RoomStateEvent.Members),
+    this.roomMembers$,
   ).pipe(
     startWith(null),
     map(() => {
@@ -496,6 +507,7 @@ export class CallViewModel extends ViewModel {
       }
       return displaynameMap;
     }),
+    this.scope.state(),
   );
 
   /**
@@ -508,10 +520,7 @@ export class CallViewModel extends ViewModel {
     // Also react to changes in the MatrixRTC session list.
     // The session list will also be update if a room membership changes.
     // No additional RoomState event listener needs to be set up.
-    fromEvent(
-      this.matrixRTCSession,
-      MatrixRTCSessionEvent.MembershipsChanged,
-    ).pipe(startWith(null)),
+    this.membershipsChanged$.pipe(startWith(null)),
     showNonMemberTiles.value$,
   ]).pipe(
     scan(

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -465,11 +465,21 @@ export class CallViewModel extends ViewModel {
       },
     );
 
+  /**
+   * Observable for changes to the MatrixRTCSession membership list.
+   *
+   * We do this to ensure that we only listen once to the event and then share internally.
+   */
   private readonly membershipsChanged$ = fromEvent(
     this.matrixRTCSession,
     MatrixRTCSessionEvent.MembershipsChanged,
   ).pipe(share());
 
+  /**
+   * Observable for changes to the Matrix Room member data.
+   *
+   * We do this to ensure that we only listen once to the event and then share internally.
+   */
   private readonly roomMembers$ = fromEvent(
     this.matrixRTCSession.room,
     RoomStateEvent.Members,


### PR DESCRIPTION
On top of https://github.com/element-hq/element-call/pull/3062 a potential refactor for a clearer data flow.

Calls to `fromEvent()` are piped via `share()` to multiplex subscribers.