### PR TITLE
Always run build CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,16 +5,8 @@ on:
       - synchronize
       - opened
       - labeled
-    paths-ignore:
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/CODEOWNERS"
-      - "docs/**"
   push:
     branches: [livekit, full-mesh]
-    paths-ignore:
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/CODEOWNERS"
-      - "docs/**"
 jobs:
   build_full_element_call:
     # Use the full package vite build


### PR DESCRIPTION
As identified in https://github.com/element-hq/element-call/pull/3116#issuecomment-2759148857 depending on the contents of a PR it may not be possible to merge due to required workflows not actually being run.

This change will mean that the build CI workflow is run irrespective of the contents.