### PR TITLE
Add deafen toggle to mute all incoming audio

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -61,6 +61,7 @@
     "username": "Username",
     "video": "Video"
   },
+  "deafen_button_label": "Deafen",
   "developer_mode": {
     "always_show_iphone_earpiece": "Show iPhone earpiece option on all platforms",
     "crypto_version": "Crypto version: {{version}}",
@@ -245,6 +246,7 @@
   "unauthenticated_view_body": "Not registered yet? <2>Create an account</2>",
   "unauthenticated_view_login_button": "Login to your account",
   "unauthenticated_view_ssla_caption": "By clicking \"Go\", you agree to our <2>Software and Services License Agreement (SSLA)</2>",
+  "undeafen_button_label": "Undeafen",
   "unmute_microphone_button_label": "Unmute microphone",
   "version": "{{productName}} version: {{version}}",
   "video_tile": {
@@ -252,6 +254,7 @@
     "camera_starting": "Video loading...",
     "change_fit_contain": "Fit to frame",
     "collapse": "Collapse",
+    "deafened": "Deafened",
     "expand": "Expand",
     "mute_for_me": "Mute for me",
     "muted_for_me": "Muted for me",

--- a/sdk/main.ts
+++ b/sdk/main.ts
@@ -142,6 +142,7 @@ export async function createMatrixRTCSdk(
     { encryptionSystem: { kind: E2eeType.PER_PARTICIPANT } },
     of({}),
     of({}),
+    of({}),
     constant({ supported: false, processor: undefined }),
   );
   logger.info("CallViewModelCreated");

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -17,6 +17,8 @@ import {
   EndCallIcon,
   ShareScreenSolidIcon,
   SettingsSolidIcon,
+  HeadphonesSolidIcon,
+  HeadphonesOffSolidIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import styles from "./Button.module.css";
@@ -39,6 +41,33 @@ export const MicButton: FC<MicButtonProps> = ({ muted, ...props }) => {
         aria-label={label}
         Icon={Icon}
         kind={muted ? "primary" : "secondary"}
+        {...props}
+      />
+    </Tooltip>
+  );
+};
+
+interface DeafenButtonProps extends ComponentPropsWithoutRef<"button"> {
+  deafened: boolean;
+}
+
+export const DeafenButton: FC<DeafenButtonProps> = ({
+  deafened,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const Icon = deafened ? HeadphonesOffSolidIcon : HeadphonesSolidIcon;
+  const label = deafened
+    ? t("undeafen_button_label")
+    : t("deafen_button_label");
+
+  return (
+    <Tooltip label={label}>
+      <CpdButton
+        iconOnly
+        aria-label={label}
+        Icon={Icon}
+        kind={deafened ? "primary" : "secondary"}
         {...props}
       />
     </Tooltip>

--- a/src/reactions/DeafenReader.ts
+++ b/src/reactions/DeafenReader.ts
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import {
+  type CallMembership,
+  MatrixRTCSessionEvent,
+  type MatrixRTCSession,
+} from "matrix-js-sdk/lib/matrixrtc";
+import { logger } from "matrix-js-sdk/lib/logger";
+import { type MatrixEvent, MatrixEventEvent } from "matrix-js-sdk";
+import { type ReactionEventContent } from "matrix-js-sdk/lib/types";
+import {
+  RelationType,
+  EventType,
+  RoomEvent as MatrixRoomEvent,
+} from "matrix-js-sdk";
+import { BehaviorSubject } from "rxjs";
+
+import { ElementCallDeafenedKey, type DeafenedInfo } from ".";
+import { type ObservableScope } from "../state/ObservableScope";
+
+/**
+ * Listens for deafen state reactions from an RTCSession and populates a subject
+ * for consumption by the CallViewModel.
+ */
+export class DeafenReader {
+  private readonly deafenedSubject$ = new BehaviorSubject<
+    Record<string, DeafenedInfo>
+  >({});
+
+  /**
+   * The latest set of deafened users.
+   */
+  public readonly deafened$ = this.deafenedSubject$.asObservable();
+
+  public constructor(
+    private readonly scope: ObservableScope,
+    private readonly rtcSession: MatrixRTCSession,
+  ) {
+    this.rtcSession.room.on(MatrixRoomEvent.Timeline, this.handleEvent);
+    this.scope.onEnd(() =>
+      this.rtcSession.room.off(MatrixRoomEvent.Timeline, this.handleEvent),
+    );
+
+    this.rtcSession.room.on(MatrixRoomEvent.Redaction, this.handleEvent);
+    this.scope.onEnd(() =>
+      this.rtcSession.room.off(MatrixRoomEvent.Redaction, this.handleEvent),
+    );
+
+    this.rtcSession.room.client.on(
+      MatrixEventEvent.Decrypted,
+      this.handleEvent,
+    );
+    this.scope.onEnd(() =>
+      this.rtcSession.room.client.off(
+        MatrixEventEvent.Decrypted,
+        this.handleEvent,
+      ),
+    );
+
+    this.rtcSession.room.on(
+      MatrixRoomEvent.LocalEchoUpdated,
+      this.handleEvent,
+    );
+    this.scope.onEnd(() =>
+      this.rtcSession.room.off(
+        MatrixRoomEvent.LocalEchoUpdated,
+        this.handleEvent,
+      ),
+    );
+
+    this.rtcSession.on(
+      MatrixRTCSessionEvent.MembershipsChanged,
+      this.onMembershipsChanged,
+    );
+    this.scope.onEnd(() =>
+      this.rtcSession.off(
+        MatrixRTCSessionEvent.MembershipsChanged,
+        this.onMembershipsChanged,
+      ),
+    );
+
+    // Run this once to ensure we have fetched the state from the call.
+    this.onMembershipsChanged([]);
+  }
+
+  /**
+   * Fetches any deafen reactions by the given sender on the given
+   * membership event.
+   */
+  private getLastDeafenEvent(
+    membershipEventId: string,
+    expectedSender: string,
+  ): MatrixEvent | undefined {
+    const relations = this.rtcSession.room.relations.getChildEventsForEvent(
+      membershipEventId,
+      RelationType.Annotation,
+      EventType.Reaction,
+    );
+    const allEvents = relations?.getRelations() ?? [];
+    return allEvents.find(
+      (reaction) =>
+        reaction.event.sender === expectedSender &&
+        reaction.getType() === EventType.Reaction &&
+        reaction.getContent()?.["m.relates_to"]?.key ===
+          ElementCallDeafenedKey,
+    );
+  }
+
+  private onMembershipsChanged = (oldMemberships: CallMembership[]): void => {
+    // Remove deafen state for users no longer joined to the call.
+    for (const identifier of Object.keys(this.deafenedSubject$.value).filter(
+      (id) => oldMemberships.find((u) => u.userId == id),
+    )) {
+      this.removeDeafened(identifier);
+    }
+
+    // For each member in the call, check to see if a deafen reaction exists.
+    for (const m of this.rtcSession.memberships) {
+      if (!m.userId || !m.eventId) {
+        continue;
+      }
+      const identifier = `${m.userId}:${m.deviceId}`;
+      if (
+        this.deafenedSubject$.value[identifier] &&
+        this.deafenedSubject$.value[identifier].membershipEventId !== m.eventId
+      ) {
+        // Membership event for sender has changed since deafen was set, reset.
+        this.removeDeafened(identifier);
+      }
+      const reaction = this.getLastDeafenEvent(m.eventId, m.userId);
+      if (reaction) {
+        const eventId = reaction?.getId();
+        if (!eventId) {
+          continue;
+        }
+        this.addDeafened(`${m.userId}:${m.deviceId}`, {
+          membershipEventId: m.eventId,
+          reactionEventId: eventId,
+        });
+      }
+    }
+  };
+
+  private addDeafened(identifier: string, info: DeafenedInfo): void {
+    this.deafenedSubject$.next({
+      ...this.deafenedSubject$.value,
+      [identifier]: info,
+    });
+  }
+
+  private removeDeafened(identifier: string): void {
+    this.deafenedSubject$.next(
+      Object.fromEntries(
+        Object.entries(this.deafenedSubject$.value).filter(
+          ([uId]) => uId !== identifier,
+        ),
+      ),
+    );
+  }
+
+  private handleEvent = (event: MatrixEvent): void => {
+    const room = this.rtcSession.room;
+    if (event.getRoomId() !== room.roomId) return;
+    if (event.isSending()) return;
+
+    const sender = event.getSender();
+    const reactionEventId = event.getId();
+    if (!sender || !reactionEventId) return;
+
+    room.client
+      .decryptEventIfNeeded(event)
+      .catch((e) => logger.warn(`Failed to decrypt ${event.getId()}`, e));
+    if (event.isBeingDecrypted() || event.isDecryptionFailure()) return;
+
+    if (event.getType() === EventType.Reaction) {
+      const content = event.getContent() as ReactionEventContent;
+      const membershipEventId = content["m.relates_to"].event_id;
+
+      const membershipEvent = this.rtcSession.memberships.find(
+        (e) => e.eventId === membershipEventId && e.userId === sender,
+      );
+      if (!membershipEvent) {
+        return;
+      }
+
+      if (content?.["m.relates_to"].key === ElementCallDeafenedKey) {
+        this.addDeafened(
+          `${membershipEvent.userId}:${membershipEvent.deviceId}`,
+          {
+            reactionEventId,
+            membershipEventId,
+          },
+        );
+      }
+    } else if (event.getType() === EventType.RoomRedaction) {
+      const targetEvent = event.event.redacts;
+      const targetUser = Object.entries(this.deafenedSubject$.value).find(
+        ([_u, r]) => r.reactionEventId === targetEvent,
+      )?.[0];
+      if (!targetUser) {
+        return;
+      }
+      this.removeDeafened(targetUser);
+    }
+  };
+}

--- a/src/reactions/index.ts
+++ b/src/reactions/index.ts
@@ -204,6 +204,19 @@ export const ReactionSet: ReactionOption[] = [
   },
 ];
 
+export const ElementCallDeafenedKey = "io.element.call.deafened";
+
+export interface DeafenedInfo {
+  /**
+   * Call membership event that was reacted to.
+   */
+  membershipEventId: string;
+  /**
+   * Event ID of the reaction itself.
+   */
+  reactionEventId: string;
+}
+
 export interface RaisedHandInfo {
   /**
    * Call membership event that was reacted to.

--- a/src/reactions/useReactionsSender.tsx
+++ b/src/reactions/useReactionsSender.tsx
@@ -19,13 +19,18 @@ import { logger } from "matrix-js-sdk/lib/logger";
 
 import { useMatrixRTCSessionMemberships } from "../useMatrixRTCSessionMemberships";
 import { useClientState } from "../ClientContext";
-import { ElementCallReactionEventType, type ReactionOption } from ".";
+import {
+  ElementCallDeafenedKey,
+  ElementCallReactionEventType,
+  type ReactionOption,
+} from ".";
 import { type CallViewModel } from "../state/CallViewModel/CallViewModel";
 import { useBehavior } from "../useBehavior";
 
 interface ReactionsSenderContextType {
   supportsReactions: boolean;
   toggleRaisedHand: () => Promise<void>;
+  toggleDeafened: () => Promise<void>;
   sendReaction: (reaction: ReactionOption) => Promise<void>;
 }
 
@@ -88,6 +93,15 @@ export const ReactionsSenderProvider = ({
     [myMembershipIdentifier, handsRaised],
   );
 
+  const deafened = useBehavior(vm.deafened$);
+  const myDeafened = useMemo(
+    () =>
+      myMembershipIdentifier !== undefined
+        ? deafened[myMembershipIdentifier]
+        : undefined,
+    [myMembershipIdentifier, deafened],
+  );
+
   const toggleRaisedHand = useCallback(async () => {
     if (!myMembershipIdentifier) {
       return;
@@ -131,6 +145,56 @@ export const ReactionsSenderProvider = ({
     room,
   ]);
 
+  const toggleDeafened = useCallback(async () => {
+    if (!myMembershipIdentifier) {
+      return;
+    }
+    const myDeafenedReactionId = myDeafened?.reactionEventId;
+
+    if (!myDeafenedReactionId) {
+      try {
+        if (!myMembershipEvent) {
+          throw new Error("Cannot find own membership event");
+        }
+        const reaction = await room.client.sendEvent(
+          rtcSession.room.roomId,
+          EventType.Reaction,
+          {
+            "m.relates_to": {
+              rel_type: RelationType.Annotation,
+              event_id: myMembershipEvent,
+              key: ElementCallDeafenedKey,
+            },
+          },
+        );
+        logger.debug("Sent deafen event", reaction.event_id);
+      } catch (ex) {
+        logger.error("Failed to send deafen event", ex);
+      }
+    } else {
+      try {
+        await room.client.redactEvent(
+          rtcSession.room.roomId,
+          myDeafenedReactionId,
+        );
+        logger.debug("Redacted deafen event");
+      } catch (ex) {
+        logger.error(
+          "Failed to redact deafen event",
+          myDeafenedReactionId,
+          ex,
+        );
+        throw ex;
+      }
+    }
+  }, [
+    myMembershipEvent,
+    myMembershipIdentifier,
+    myDeafened,
+    rtcSession,
+    room,
+  ]);
+
   const sendReaction = useCallback(
     async (reaction: ReactionOption) => {
       if (!myMembershipIdentifier || myReaction) {
@@ -161,6 +225,7 @@ export const ReactionsSenderProvider = ({
       value={{
         supportsReactions,
         toggleRaisedHand,
+        toggleDeafened,
         sendReaction,
       }}
     >

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -36,6 +36,7 @@ import LogoType from "../icons/LogoType.svg?react";
 import {
   EndCallButton,
   MicButton,
+  DeafenButton,
   VideoButton,
   ShareScreenButton,
   SettingsButton,
@@ -90,6 +91,11 @@ import {
   useSetting,
 } from "../settings/settings";
 import { ReactionsReader } from "../reactions/ReactionsReader";
+import { DeafenReader } from "../reactions/DeafenReader";
+import {
+  deafened$ as localDeafened$,
+  toggleDeafen,
+} from "../state/DeafenModel";
 import { LivekitRoomAudioRenderer } from "../livekit/MatrixAudioRenderer.tsx";
 import { muteAllAudio$ } from "../state/MuteAllAudioModel.ts";
 import { useMediaDevices } from "../MediaDevicesContext.ts";
@@ -133,6 +139,7 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
     logger.info("START CALL VIEW SCOPE");
     const scope = new ObservableScope();
     const reactionsReader = new ReactionsReader(scope, props.rtcSession);
+    const deafenReader = new DeafenReader(scope, props.rtcSession);
     const { autoLeaveWhenOthersLeft, waitForCallPickup, sendNotificationType } =
       urlParams;
     const vm = createCallViewModel$(
@@ -149,6 +156,7 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
       },
       reactionsReader.raisedHands$,
       reactionsReader.reactions$,
+      deafenReader.deafened$,
       scope.behavior(trackProcessorState$),
     );
     // TODO move this somewhere else once we use the callViewModel in the lobby as well!
@@ -203,8 +211,12 @@ export const InCallView: FC<InCallViewProps> = ({
   onShareClick,
 }) => {
   const { t } = useTranslation();
-  const { supportsReactions, sendReaction, toggleRaisedHand } =
-    useReactionsSender();
+  const {
+    supportsReactions,
+    sendReaction,
+    toggleRaisedHand,
+    toggleDeafened: broadcastToggleDeafened,
+  } = useReactionsSender();
 
   useWakeLock();
   // TODO-MULTI-SFU This is unused now??
@@ -248,15 +260,36 @@ export const InCallView: FC<InCallViewProps> = ({
   const toggleVideo = useBehavior(muteStates.video.toggle$);
   const setAudioEnabled = useBehavior(muteStates.audio.setEnabled$);
 
+  const deafened = useBehavior(localDeafened$);
+  const prevAudioEnabledRef = useRef(audioEnabled);
+
+  const handleToggleDeafen = useCallback(() => {
+    if (!deafened) {
+      // About to deafen: save current mic state, then mute mic
+      prevAudioEnabledRef.current = audioEnabled;
+      if (audioEnabled) {
+        setAudioEnabled?.(false);
+      }
+    } else {
+      // About to un-deafen: restore previous mic state
+      if (prevAudioEnabledRef.current) {
+        setAudioEnabled?.(true);
+      }
+    }
+    toggleDeafen();
+    void broadcastToggleDeafened();
+  }, [deafened, audioEnabled, setAudioEnabled, broadcastToggleDeafened]);
+
   // This function incorrectly assumes that there is a camera and microphone, which is not always the case.
   // TODO: Make sure that this module is resilient when it comes to camera/microphone availability!
   useCallViewKeyboardShortcuts(
     containerRef1,
-    toggleAudio,
+    deafened ? null : toggleAudio,
     toggleVideo,
-    setAudioEnabled,
+    deafened ? null : setAudioEnabled,
     (reaction) => void sendReaction(reaction),
     () => void toggleRaisedHand(),
+    handleToggleDeafen,
   );
 
   const audioParticipants = useBehavior(vm.livekitRoomItems$);
@@ -665,11 +698,18 @@ export const InCallView: FC<InCallViewProps> = ({
   buttons.push(
     <MicButton
       key="audio"
-      muted={!audioEnabled}
-      onClick={toggleAudio ?? undefined}
+      muted={!audioEnabled || deafened}
+      onClick={deafened ? undefined : (toggleAudio ?? undefined)}
       onTouchEnd={onControlsTouchEnd}
-      disabled={toggleAudio === null}
+      disabled={toggleAudio === null || deafened}
       data-testid="incall_mute"
+    />,
+    <DeafenButton
+      key="deafen"
+      deafened={deafened}
+      onClick={handleToggleDeafen}
+      onTouchEnd={onControlsTouchEnd}
+      data-testid="incall_deafen"
     />,
     <VideoButton
       key="video"

--- a/src/room/__snapshots__/InCallView.test.tsx.snap
+++ b/src/room/__snapshots__/InCallView.test.tsx.snap
@@ -309,9 +309,32 @@ exports[`InCallView > rendering > renders 1`] = `
           </svg>
         </button>
         <button
+          aria-label="Deafen"
+          aria-labelledby="_r_d_"
+          class="_button_13vu4_8 _has-icon_13vu4_60 _icon-only_13vu4_53"
+          data-kind="secondary"
+          data-size="lg"
+          data-testid="incall_deafen"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 3a8 8 0 0 0-8 8v3h2a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-9C2 5.477 6.477 1 12 1s10 4.477 10 10v9a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h2v-3a8 8 0 0 0-8-8"
+            />
+          </svg>
+        </button>
+        <button
           aria-disabled="true"
           aria-label="Start video"
-          aria-labelledby="_r_d_"
+          aria-labelledby="_r_i_"
           class="_button_13vu4_8 _has-icon_13vu4_60 _icon-only_13vu4_53"
           data-kind="primary"
           data-size="lg"
@@ -333,7 +356,7 @@ exports[`InCallView > rendering > renders 1`] = `
           </svg>
         </button>
         <button
-          aria-labelledby="_r_i_"
+          aria-labelledby="_r_n_"
           class="_button_13vu4_8 _has-icon_13vu4_60 _icon-only_13vu4_53"
           data-kind="secondary"
           data-size="lg"
@@ -355,7 +378,7 @@ exports[`InCallView > rendering > renders 1`] = `
         </button>
         <button
           aria-label="End call"
-          aria-labelledby="_r_n_"
+          aria-labelledby="_r_s_"
           class="_button_13vu4_8 endCall _has-icon_13vu4_60 _icon-only_13vu4_53 _destructive_13vu4_110"
           data-kind="primary"
           data-size="lg"
@@ -381,7 +404,7 @@ exports[`InCallView > rendering > renders 1`] = `
         class="toggle layout"
       >
         <input
-          aria-labelledby="_r_s_"
+          aria-labelledby="_r_11_"
           name="layout"
           type="radio"
           value="spotlight"
@@ -399,7 +422,7 @@ exports[`InCallView > rendering > renders 1`] = `
           />
         </svg>
         <input
-          aria-labelledby="_r_11_"
+          aria-labelledby="_r_16_"
           checked=""
           name="layout"
           type="radio"

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -72,6 +72,7 @@ import { oneOnOneLayout } from "../OneOnOneLayout";
 import { pipLayout } from "../PipLayout";
 import { type EncryptionSystem } from "../../e2ee/sharedKeyManagement";
 import {
+  type DeafenedInfo,
   type RaisedHandInfo,
   type ReactionInfo,
   type ReactionOption,
@@ -286,6 +287,8 @@ export interface CallViewModel {
   localMatrixLivekitMember$: Behavior<LocalMatrixLivekitMember | null>;
   /** List of participants raising their hand */
   handsRaised$: Behavior<Record<string, RaisedHandInfo>>;
+  /** List of deafened participants */
+  deafened$: Behavior<Record<string, DeafenedInfo>>;
   /** List of reactions. Keys are: membership.membershipId (currently predefined as: `${membershipEvent.userId}:${membershipEvent.deviceId}`)*/
   reactions$: Behavior<Record<string, ReactionOption>>;
 
@@ -391,6 +394,7 @@ export function createCallViewModel$(
   options: CallViewModelOptions,
   handsRaisedSubject$: Observable<Record<string, RaisedHandInfo>>,
   reactionsSubject$: Observable<Record<string, ReactionInfo>>,
+  deafenedSubject$: Observable<Record<string, DeafenedInfo>>,
   trackProcessorState$: Behavior<ProcessorState>,
 ): CallViewModel {
   const client = matrixRoom.client;
@@ -697,6 +701,10 @@ export function createCallViewModel$(
     handsRaisedSubject$.pipe(pauseWhen(localMembership.reconnecting$)),
   );
 
+  const deafened$ = scope.behavior(
+    deafenedSubject$.pipe(pauseWhen(localMembership.reconnecting$)),
+  );
+
   const reactions$ = scope.behavior(
     reactionsSubject$.pipe(
       map((v) =>
@@ -787,6 +795,9 @@ export function createCallViewModel$(
             ),
             reaction$: scope.behavior(
               reactions$.pipe(map((v) => v[mediaId] ?? undefined)),
+            ),
+            deafened$: scope.behavior(
+              deafened$.pipe(map((v) => v[mediaId] !== undefined)),
             ),
           }),
       ),
@@ -1514,6 +1525,7 @@ export function createCallViewModel$(
     allConnections$,
     participantCount$: participantCount$,
     handsRaised$: handsRaised$,
+    deafened$: deafened$,
     reactions$: reactions$,
     joinSoundEffect$: joinSoundEffect$,
     leaveSoundEffect$: leaveSoundEffect$,

--- a/src/state/CallViewModel/CallViewModelTestUtils.ts
+++ b/src/state/CallViewModel/CallViewModelTestUtils.ts
@@ -187,6 +187,7 @@ export function withCallViewModel(mode: MatrixRTCMode) {
       },
       raisedHands$,
       reactions$,
+      new BehaviorSubject<Record<string, never>>({}),
       new BehaviorSubject<ProcessorState>({
         processor: undefined,
         supported: undefined,

--- a/src/state/DeafenModel.ts
+++ b/src/state/DeafenModel.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { BehaviorSubject } from "rxjs";
+
+/**
+ * Whether the local user is currently deafened (all incoming audio muted).
+ */
+export const deafened$ = new BehaviorSubject(false);
+
+/**
+ * Toggle the local deafen state.
+ */
+export function toggleDeafen(): void {
+  deafened$.next(!deafened$.value);
+}

--- a/src/state/MuteAllAudioModel.ts
+++ b/src/state/MuteAllAudioModel.ts
@@ -10,13 +10,19 @@ import { combineLatest, startWith } from "rxjs";
 import { setAudioEnabled$ } from "../controls";
 import { muteAllAudio as muteAllAudioSetting } from "../settings/settings";
 import { globalScope } from "./ObservableScope";
+import { deafened$ } from "./DeafenModel";
 
 /**
  * This can transition into sth more complete: `GroupCallViewModel.ts`
  */
 export const muteAllAudio$ = globalScope.behavior(
   combineLatest(
-    [setAudioEnabled$.pipe(startWith(true)), muteAllAudioSetting.value$],
-    (outputEnabled, settingsMute) => !outputEnabled || settingsMute,
+    [
+      setAudioEnabled$.pipe(startWith(true)),
+      muteAllAudioSetting.value$,
+      deafened$,
+    ],
+    (outputEnabled, settingsMute, deafened) =>
+      !outputEnabled || settingsMute || deafened,
   ),
 );

--- a/src/state/media/UserMediaViewModel.ts
+++ b/src/state/media/UserMediaViewModel.ts
@@ -54,6 +54,7 @@ export interface BaseUserMediaViewModel extends MemberMediaViewModel {
   rtcBackendIdentity: string;
   handRaised$: Behavior<Date | null>;
   reaction$: Behavior<ReactionOption | null>;
+  deafened$: Behavior<boolean>;
   audioStreamStats$: Observable<
     RTCInboundRtpStreamStats | RTCOutboundRtpStreamStats | undefined
   >;
@@ -69,6 +70,7 @@ export interface BaseUserMediaInputs extends Omit<
   rtcBackendIdentity: string;
   handRaised$: Behavior<Date | null>;
   reaction$: Behavior<ReactionOption | null>;
+  deafened$: Behavior<boolean>;
   statsType: "inbound-rtp" | "outbound-rtp";
 }
 
@@ -78,6 +80,7 @@ export function createBaseUserMedia(
     rtcBackendIdentity,
     handRaised$,
     reaction$,
+    deafened$,
     statsType,
     ...inputs
   }: BaseUserMediaInputs,
@@ -120,6 +123,7 @@ export function createBaseUserMedia(
     rtcBackendIdentity,
     handRaised$,
     reaction$,
+    deafened$,
     audioStreamStats$: combineLatest([
       participant$,
       showConnectionStats.value$,

--- a/src/tile/GridTile.test.tsx
+++ b/src/tile/GridTile.test.tsx
@@ -60,6 +60,7 @@ test("GridTile is accessible", async () => {
   const cVm = {
     reactions$: constant({}),
     handsRaised$: constant({}),
+    deafened$: constant({}),
   } as Partial<CallViewModel> as CallViewModel;
   const { container } = render(
     <ReactionsSenderProvider vm={cVm} rtcSession={fakeRtcSession}>

--- a/src/tile/GridTile.tsx
+++ b/src/tile/GridTile.tsx
@@ -29,6 +29,7 @@ import {
   ExpandIcon,
   VolumeOffSolidIcon,
   SwitchCameraSolidIcon,
+  HeadphonesOffSolidIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
 import {
   ContextMenu,
@@ -114,6 +115,7 @@ const UserMediaTile: FC<UserMediaTileProps> = ({
   const rtcBackendIdentity = vm.rtcBackendIdentity;
   const handRaised = useBehavior(vm.handRaised$);
   const reaction = useBehavior(vm.reaction$);
+  const deafened = useBehavior(vm.deafened$);
 
   const AudioIcon = playbackMuted
     ? VolumeOffSolidIcon
@@ -160,13 +162,23 @@ const UserMediaTile: FC<UserMediaTileProps> = ({
         [styles.handRaised]: !showSpeaking && handRaised,
       })}
       nameTagLeadingIcon={
-        <AudioIcon
-          width={20}
-          height={20}
-          aria-label={audioIconLabel}
-          data-muted={playbackMuted || !audioEnabled}
-          className={styles.muteIcon}
-        />
+        <>
+          <AudioIcon
+            width={20}
+            height={20}
+            aria-label={audioIconLabel}
+            data-muted={playbackMuted || !audioEnabled}
+            className={styles.muteIcon}
+          />
+          {deafened && (
+            <HeadphonesOffSolidIcon
+              width={20}
+              height={20}
+              aria-label={t("video_tile.deafened")}
+              className={styles.muteIcon}
+            />
+          )}
+        </>
       }
       displayName={displayName}
       mxcAvatarUrl={mxcAvatarUrl}

--- a/src/useCallViewKeyboardShortcuts.test.tsx
+++ b/src/useCallViewKeyboardShortcuts.test.tsx
@@ -43,6 +43,7 @@ const TestComponent: FC<TestComponentProps> = ({
     setAudioEnabled,
     sendReaction,
     toggleHandRaised,
+    () => {},
   );
   return (
     <div ref={ref}>

--- a/src/useCallViewKeyboardShortcuts.ts
+++ b/src/useCallViewKeyboardShortcuts.ts
@@ -34,6 +34,7 @@ export function useCallViewKeyboardShortcuts(
   setAudioEnabled: ((enabled: boolean) => void) | null,
   sendReaction: (reaction: ReactionOption) => void,
   toggleHandRaised: () => void,
+  toggleDeafen: () => void,
 ): void {
   const spacebarHeld = useRef(false);
 
@@ -65,6 +66,9 @@ export function useCallViewKeyboardShortcuts(
         } else if (event.key === "h") {
           event.preventDefault();
           toggleHandRaised();
+        } else if (event.key === "d") {
+          event.preventDefault();
+          toggleDeafen();
         } else if (KeyToReactionMap[event.key]) {
           event.preventDefault();
           sendReaction(KeyToReactionMap[event.key]);
@@ -77,6 +81,7 @@ export function useCallViewKeyboardShortcuts(
         setAudioEnabled,
         sendReaction,
         toggleHandRaised,
+        toggleDeafen,
       ],
     ),
     // Because this is set on the window, to prevent shortcuts from activating

--- a/src/utils/test-viewmodel.ts
+++ b/src/utils/test-viewmodel.ts
@@ -168,6 +168,7 @@ export function getBasicCallViewModelEnvironment(
     },
     handRaisedSubject$,
     reactionsSubject$,
+    new BehaviorSubject({}),
     constant({ processor: undefined, supported: false }),
   );
   return {

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -347,6 +347,7 @@ export function mockLocalMedia(
     mxcAvatarUrl$: constant(member.getMxcAvatarUrl()),
     handRaised$: constant(null),
     reaction$: constant(null),
+    deafened$: constant(false),
   });
 }
 
@@ -390,6 +391,7 @@ export function mockRemoteMedia(
     mxcAvatarUrl$: constant(member.getMxcAvatarUrl()),
     handRaised$: constant(null),
     reaction$: constant(null),
+    deafened$: constant(false),
   });
 }
 


### PR DESCRIPTION
## Summary
- Add deafen event type and DeafenReader for reading remote deafen state from Matrix room events
- Add local deafen toggle with muteAllAudio$ integration to suppress all incoming audio
- Thread deafened$ observable through CallViewModel and UserMediaViewModel for UI state
- Add DeafenButton component and deafened indicator on participant tiles
- Broadcast deafen state to other participants via ReactionsSenderProvider
- Wire deafen button into the call toolbar with auto-mute mic on deafen (restores previous state on un-deafen), 'd' keyboard shortcut, and translation keys

## Test plan
- [x] Verify deafen button appears in the call toolbar and toggles deafen state
- [x] Confirm all incoming audio is silenced when deafened
- [x] Test that microphone is auto-muted when deafening and restored to previous state on un-deafen
- [x] Verify mic toggle is disabled while deafened
- [x] Test 'd' keyboard shortcut toggles deafen
- [x] Confirm deafened indicator appears on the local participant's tile
- [ ] Verify deafen state is broadcast to and visible by other participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)