### PR TITLE
Make sdk build compatible with content loaded action

### DIFF
--- a/sdk/main.ts
+++ b/sdk/main.ts
@@ -298,8 +298,10 @@ export async function createMatrixRTCSdk(
     void scheduleWidgetCloseOnLeave();
   });
 
-  logger.info("createMatrixRTCSdk done");
-
+  logger.info(
+    "createMatrixRTCSdk done (all listeners setup) -> sendContentLoaded",
+  );
+  await widget.api.sendContentLoaded();
   return {
     join: (): void => {
       // first lets try making the widget sticky


### PR DESCRIPTION
This is a lost branch which was done in the context of the FOSDEM demo.
Adding a PR so we dont lose it.

If this is not set widget setup for waitForIFrameLoaded=false will never start. And waitForIFrameLoaded=true might lead to races on widget startup...
So the only good way to do this is `waitForIFrameLoaded=false` so we need `sendContentLoaded` (we do the same for element call anyways)