### PR TITLE
devx: Enable msc4143 on other homeserver (remove well-known)

### DIFF
--- a/backend/dev_homeserver-othersite.yaml
+++ b/backend/dev_homeserver-othersite.yaml
@@ -40,6 +40,8 @@ experimental_features:
   msc4222_enabled: true
   # sticky events for MatrixRTC user state
   msc4354_enabled: true
+  # MSC4143: RTC Transport end point
+  msc4143_enabled: true
 
 # The maximum allowed duration by which sent events can be delayed, as
 # per MSC4140. Must be a positive value if set.  Defaults to no
@@ -64,3 +66,8 @@ rc_message:
   # Currently the heart-beat is every 5 seconds which translates into a rate of 0.2s
   per_second: 0.5
   burst_count: 30
+
+matrix_rtc:
+  transports:
+    - type: livekit
+      livekit_service_url: https://matrix-rtc.othersite.m.localhost/livekit/jwt

--- a/backend/dev_nginx.conf
+++ b/backend/dev_nginx.conf
@@ -60,7 +60,8 @@ server {
     # setting for livekit_service_url
     location /.well-known/matrix/client {
         add_header Access-Control-Allow-Origin *;
-        return 200 '{"m.homeserver": {"base_url": "https://synapse.othersite.m.localhost"}, "org.matrix.msc4143.rtc_foci": [{"type": "livekit", "livekit_service_url": "https://matrix-rtc.othersite.m.localhost/livekit/jwt"}]}';
+        # synapse.othersite supports /rtc/transport so remove the livekit_service_url from auto-discovery as it is not needed.
+        return 200 '{"m.homeserver": {"base_url": "https://synapse.othersite.m.localhost"}}';
         default_type application/json;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Enable `/rtc/transport` MSC on the Other synaspe. Also remove the well-known for preferred foci on that domain as it is not needed anymore

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
