### PR TITLE
Draft: Docs: Add MSC4143 feature to Synapse config

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,6 +45,14 @@ experimental_features:
   # MSC4222 needed for syncv2 state_after. This allow clients to
   # correctly track the state of the room.
   msc4222_enabled: true
+  # MSC4143: MatrixRTC transports endpoint. Used by some clients to
+  # discover the MatrixRTC Authorization Service for LiveKit.
+  msc4143_enabled: true
+
+# Configure MatrixRTC Transports
+# Must replace <LIVEKIT_URL> with your server's URL.
+matrix_rtc:
+  transports: [{type: livekit, livekit_service_url: "<LIVEKIT_URL>"}]
 
 # The maximum allowed duration by which sent events can be delayed, as
 # per MSC4140.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Content

It appears that some clients now fail when MatrixRTC transports endpoint isn't available. In Synapse, this requires enabling the `msc4143_enabled` experimental feature. This change adds the necessary config to the self hosting documentation.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

After figuring this out on my own, I discovered that there was an issue that describes the same behavior: #3643

It may be that this documentation change is considered a fix to that issue, so in the spirit of the contribution guidelines: Fixes #3643

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- With a complete configuration which doesn't include `msc4143_enabled`, attempt a call from Element X Android. This fails.
- Set `msc4143_enabled` to `true` and restart Synapse. Attempt a call from Element X Android. This succeeds.

## Checklist

- [x] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
