### PR TITLE
Fix tracks not being resumed in case of a startPublishing vs track

### DIFF
--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -573,7 +573,7 @@ export function createCallViewModel$(
         mediaDevices,
         muteStates,
         trackProcessorState$,
-        logger
+        logger,
         //   .getChild(
         //   "[Publisher " + connection.transport.livekit_service_url + "]",
         // ),

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -574,10 +574,9 @@ export function createCallViewModel$(
         mediaDevices,
         muteStates,
         trackProcessorState$,
-        logger,
-        //   .getChild(
-        //   "[Publisher " + connection.transport.livekit_service_url + "]",
-        // ),
+        logger.getChild(
+          "[Publisher " + connection.transport.livekit_service_url + "]",
+        ),
       );
     },
     connectionManager,

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -573,9 +573,10 @@ export function createCallViewModel$(
         mediaDevices,
         muteStates,
         trackProcessorState$,
-        logger.getChild(
-          "[Publisher " + connection.transport.livekit_service_url + "]",
-        ),
+        logger
+        //   .getChild(
+        //   "[Publisher " + connection.transport.livekit_service_url + "]",
+        // ),
       );
     },
     connectionManager,

--- a/src/state/CallViewModel/localMember/Publisher.test.ts
+++ b/src/state/CallViewModel/localMember/Publisher.test.ts
@@ -286,6 +286,53 @@ describe("Publisher", () => {
     expect(track!.isUpstreamPaused).toBe(true);
   });
 
+  it("Resumes upstream for tracks published after startPublishing was called (slow camera)", async () => {
+    videoEnabled$.next(true);
+
+    // Simulate that the upstream ended up paused by the time the track gets
+    // published (e.g. paused while it was still unpublished).
+    const originalPublishTrack = localParticipant.publishTrack;
+    vi.mocked(localParticipant).publishTrack = vi
+      .fn()
+      .mockImplementation(async (track: LocalTrack) => {
+        await track.pauseUpstream();
+        return originalPublishTrack(track);
+      });
+
+    const resolvers = Promise.withResolvers<void>();
+    createTrackLock = resolvers.promise;
+
+    // Track creation is slow (e.g. camera hardware takes time to open)
+    await publisher.createAndSetupTracks();
+    // startPublishing runs before the camera track exists, so its
+    // resumeUpstreams call finds nothing to resume
+    await publisher.startPublishing();
+    expect(
+      localParticipant.getTrackPublication(Track.Source.Camera),
+    ).toBeUndefined();
+
+    // The camera opens and the track gets published
+    resolvers.resolve();
+    await flushPromises();
+
+    const track = localParticipant.getTrackPublication(
+      Track.Source.Camera,
+    )?.track;
+    expect(track).toBeDefined();
+    expect(track!.resumeUpstream).toHaveBeenCalled();
+    expect(track!.isUpstreamPaused).toBe(false);
+  });
+
+  it("Does not pause tracks published after the publisher was destroyed", async () => {
+    await publisher.destroy();
+
+    const track = createMockLocalTrack(Track.Source.Camera);
+    await localParticipant.publishTrack(track);
+    await flushPromises();
+
+    expect(track.pauseUpstream).not.toHaveBeenCalled();
+  });
+
   it("Ensure resume upstream when published is called", async () => {
     videoEnabled$.next(true);
     await publisher.createAndSetupTracks();

--- a/src/state/CallViewModel/localMember/Publisher.ts
+++ b/src/state/CallViewModel/localMember/Publisher.ts
@@ -126,11 +126,9 @@ export class Publisher {
       // resumeUpstreams() call found no track and did nothing. Resume here so
       // that a track published after startPublishing() actually sends media.
       // This is a no-op if the upstream is not paused.
-      this.resumeUpstreams(lkRoom, [localTrackPublication.source]).catch(
-        (e) => {
-          this.logger.error(`Failed to resume upstreams`, e);
-        },
-      );
+      localTrackPublication.resumeUpstream().catch((e) => {
+        this.logger.error(`Failed to resume upstreams`, e);
+      });
     }
     if (localTrackPublication.source === Track.Source.Microphone) {
       const muteState = this.muteStates.audio;
@@ -171,7 +169,7 @@ export class Publisher {
         }
       }
     }
-  }
+  };
   /**
    * Create and setup local audio and video tracks based on the current mute states.
    * It creates the tracks only if audio and/or video is enabled, to avoid unnecessary

--- a/src/state/CallViewModel/localMember/Publisher.ts
+++ b/src/state/CallViewModel/localMember/Publisher.ts
@@ -80,11 +80,15 @@ export class Publisher {
 
     this.connection.livekitRoom.localParticipant.on(
       ParticipantEvent.LocalTrackPublished,
-      this.onLocalTrackPublished.bind(this),
+      this.onLocalTrackPublished,
     );
   }
 
   public async destroy(): Promise<void> {
+    this.connection.livekitRoom.localParticipant.off(
+      ParticipantEvent.LocalTrackPublished,
+      this.onLocalTrackPublished,
+    );
     this.scope.end();
     this.logger.info("Scope ended -> unset handler");
     this.muteStates.audio.unsetHandler();
@@ -106,9 +110,9 @@ export class Publisher {
   // So for that we use pauseUpStream():  Stops sending media to the server by replacing
   // the sender track with null, but keeps the local MediaStreamTrack active.
   // The user can still see/hear themselves locally, but remote participants see nothing.
-  private onLocalTrackPublished(
+  private onLocalTrackPublished = (
     localTrackPublication: LocalTrackPublication,
-  ): void {
+  ): void => {
     this.logger.info("Local track published", localTrackPublication);
     const lkRoom = this.connection.livekitRoom;
     if (!this.shouldPublish) {
@@ -116,6 +120,17 @@ export class Publisher {
       this.pauseUpstreams(lkRoom, [localTrackPublication.source]).catch((e) => {
         this.logger.error(`Failed to pause upstreams`, e);
       });
+    } else {
+      // If startPublishing() ran before this track existed (track creation is
+      // not awaited and e.g. camera hardware can take a while to open), its
+      // resumeUpstreams() call found no track and did nothing. Resume here so
+      // that a track published after startPublishing() actually sends media.
+      // This is a no-op if the upstream is not paused.
+      this.resumeUpstreams(lkRoom, [localTrackPublication.source]).catch(
+        (e) => {
+          this.logger.error(`Failed to resume upstreams`, e);
+        },
+      );
     }
     if (localTrackPublication.source === Track.Source.Microphone) {
       const muteState = this.muteStates.audio;

--- a/src/state/CallViewModel/localMember/Publisher.ts
+++ b/src/state/CallViewModel/localMember/Publisher.ts
@@ -121,6 +121,7 @@ export class Publisher {
         this.logger.error(`Failed to pause upstreams`, e);
       });
     } else {
+      this.logger.info(`resumeUpstream onLocalTrackPublished`);
       // If startPublishing() ran before this track existed (track creation is
       // not awaited and e.g. camera hardware can take a while to open), its
       // resumeUpstreams() call found no track and did nothing. Resume here so


### PR DESCRIPTION

## Content
We make sure to resume upstream in case startPublish failed to do so (`resumeUpstreams` failed)
We can see this in the logs:
`No track found for source`

```
12:46:46.324 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: [ElementCall] :2 [CallViewModel][Publisher https://livekit-jwt.call.matrix.org] startPublishing called | ConsoleMessageLogger.kt:49
12:46:46.326 org.matrix.rust.sdk     io.element.android.x.debug           W  elementx: [ElementCall] :2 [CallViewModel][Publisher https://livekit-jwt.call.matrix.org] No track found for source microphone to resume upstream | ConsoleMessageLogger.kt:49
12:46:46.327 org.matrix.rust.sdk     io.element.android.x.debug           W  elementx: [ElementCall] :2 [CallViewModel][Publisher https://livekit-jwt.call.matrix.org] No track found for source camera to resume upstream | ConsoleMessageLogger.kt:49
```
(this was found with the help of an LLM)

## Motivation and context
https://matrix.to/#/!yuFzMhMqKzNFvoLqcJ:one.ems.host/$6qF5LPK58oJPOqGDLOBs-Hsb52oAPksA-3ifz9jVQqI?via=matrix.org&via=element.io&via=lant.uk
## Screenshots / GIFs

## Tests
@jmartinesp needs to test with a device where this race occurred

## Checklist

- [ ] A linked, pre-approved issue exists for this feature or UI change.
- [ ] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [ ] Pull request includes screenshots or videos for any UI changes.
- [ ] Tests written for new code (and existing touched code where feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
