### PR TITLE
Room joining: if join_rule is absent, assume public

### DIFF
--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -280,7 +280,7 @@ export const useLoadGroupCall = (
             );
           }
           if (
-            roomSummary === undefined ||
+            roomSummary?.join_rule === undefined ||
             roomSummary.join_rule === JoinRule.Public
           ) {
             room = await client.joinRoom(roomId, {


### PR DESCRIPTION
## Content

Assumes that a missing `join_rule` in a valid room summary indicates that a room is Public

## Motivation and context

https://github.com/element-hq/element-call/issues/4156

The join_rule field is optional in the spec, so this allows spec-compliant homeservers that omit that field when the default of Public is set to work with element call. 

## Screenshots / GIFs

before:
<img width="1063" height="493" alt="image" src="https://github.com/user-attachments/assets/c2d01857-e9c1-46a0-b2ea-3ecfec9bc91e" />

after:
<img width="782" height="523" alt="image" src="https://github.com/user-attachments/assets/193b2603-4e24-42c6-83c2-1ec5c2e8217d" />

## Tests

See the linked issue, tested by setting up and debugging against a running continuwuity instance.

I'd be happy to add some tests, though I'd need some guidance 

## Checklist

- [x] A linked, pre-approved issue exists for this feature or UI change.
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [x] Pull request includes screenshots or videos for any UI changes.
- [ ] Tests written for new code (and existing touched code where feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
