### PR TITLE
Fix lobby video preview losing its rounded corners in Firefox

### DIFF
--- a/src/room/VideoPreview.module.css
+++ b/src/room/VideoPreview.module.css
@@ -22,6 +22,9 @@ Please see LICENSE in the repository root for full details.
   height: 100%;
   object-fit: cover;
   background-color: var(--video-tile-background);
+  /* In FF if you add a transform: scale/translate/matrix filter on an element,
+  it'll ignore the parents' border-radius, so force back the radius to avoid UI glitch*/
+  border-radius: inherit;
 }
 
 video.mirror {


### PR DESCRIPTION
Same fix as https://github.com/element-hq/element-call/pull/4136, but for the video preview in the lobby.

|Before|After|
|-|-|
|<img width="835" height="825" alt="Screenshot From 2026-08-18 17-53-27" src="https://github.com/user-attachments/assets/92bf1956-3cf7-402c-9574-9d6bc3d8085b" />|<img width="835" height="825" alt="Screenshot From 2026-08-18 17-53-39" src="https://github.com/user-attachments/assets/43d1875f-2873-4f41-a783-a15c3ec474f5" />|