### PR TITLE
Fix periodic rageshake log flush never running

### DIFF
--- a/src/settings/rageshake.flush.test.ts
+++ b/src/settings/rageshake.flush.test.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { afterEach, expect, it, vi } from "vitest";
+
+import { init as initRageshake } from "./rageshake";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+it("flushes logs to IndexedDB periodically without an explicit flush", async () => {
+  vi.useFakeTimers();
+  const add = vi.fn();
+  const txn = {
+    oncomplete: undefined as (() => void) | undefined,
+    onerror: undefined,
+    objectStore: (name: string) =>
+      name === "logs"
+        ? {
+            add: (entry: unknown): void => {
+              add(entry);
+              queueMicrotask(() => txn.oncomplete?.());
+            },
+          }
+        : { put: vi.fn() },
+  };
+  const open = (): unknown => {
+    const req = {
+      result: { transaction: () => txn },
+      onsuccess: undefined as (() => void) | undefined,
+    };
+    queueMicrotask(() => req.onsuccess?.());
+    return req;
+  };
+  vi.stubGlobal("indexedDB", { open });
+
+  await initRageshake();
+  global.mx_rage_logger.log(1, "test", "hello from the buffer");
+  expect(add).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(add).toHaveBeenCalledOnce();
+  expect(add.mock.calls[0][0]).toMatchObject({
+    lines: expect.stringContaining("hello from the buffer"),
+  });
+});

--- a/src/settings/rageshake.ts
+++ b/src/settings/rageshake.ts
@@ -204,10 +204,13 @@ class IndexedDBLogStore {
   // Throttled function to flush logs. We use throttle rather
   // than debounce as we want logs to be written regularly, otherwise
   // if there's a constant stream of logging, we'd never write anything.
-  private throttledFlush = throttle(() => this.flush, MAX_FLUSH_INTERVAL_MS, {
-    leading: false,
-    trailing: true,
-  });
+  private throttledFlush = throttle(
+    () => {
+      this.flush().catch((e) => logger.error("Failed to flush logs", e));
+    },
+    MAX_FLUSH_INTERVAL_MS,
+    { leading: false, trailing: true },
+  );
 
   /**
    * Flush logs to disk.


### PR DESCRIPTION
## Content

`IndexedDBLogStore.throttledFlush` was `throttle(() => this.flush, ...)`: the arrow returned the method without invoking it, so the periodic flush has been a no-op since #2607 (2024-09-10) rewrote `() => { this.flush(); }` for the promise lint rules. Logs were only written to IndexedDB on rageshake submission or `beforeunload`.

This restores the call, with the rejection logged the same way as the `beforeunload` flush.

## Motivation and context

Bug fix. Found while triaging element-hq/element-call-rageshakes#17265 / #17266: the user reported a problem from an earlier call and filed a rageshake from a later one. The earlier call's logs were absent because the host removes the widget iframe at hangup, which does not fire `beforeunload`, so nothing from that instance was ever persisted (the only surviving line was "Log database was created"). Any embedded-call rageshake filed after hangup currently carries no logs from the affected call.

## Tests

- Unit test: a stubbed IndexedDB receives the buffered lines 2s after a log call, with no explicit `flush()`. The test fails against the previous code.
- Code inspection: `git blame` on the line shows the regression in #2607; `throttle` receives a callback that now actually invokes `flush()`.
- Rageshakes from the field confirm the symptom: previous-instance logs only survive when that instance submitted a rageshake itself (e.g. #17266's `logs-0001`).

## Checklist

- [x] Bug fix, no UI change, no pre-approved issue required.
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [ ] Pull request includes screenshots or videos for any UI changes. (n/a)
- [x] Tests written for new code: `rageshake.flush.test.ts` fails on the old callback and passes with the fix.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)

(generated by fable)
