### PR TITLE
Don't report an aborted connect as a connection error

### DIFF
--- a/src/state/CallViewModel/remoteMembers/Connection.test.ts
+++ b/src/state/CallViewModel/remoteMembers/Connection.test.ts
@@ -391,6 +391,34 @@ describe("Start connection states", () => {
     expect(connectedState).toEqual(ConnectionState.LivekitConnected);
   });
 
+  it("stopping while connecting does not report an error", async () => {
+    setupTest();
+    const connection = setupRemoteConnection();
+
+    const capturedStates: (ConnectionState | Error)[] = [];
+    const s = connection.state$.subscribe((value) => {
+      capturedStates.push(value);
+    });
+    onTestFinished(() => s.unsubscribe());
+
+    // livekit-client rejects a pending connect() when disconnect() is called.
+    const pendingConnect = Promise.withResolvers<void>();
+    fakeLivekitRoom.connect.mockReturnValue(pendingConnect.promise);
+    fakeLivekitRoom.disconnect.mockResolvedValue(undefined);
+
+    const started = connection.start();
+    await vi.waitFor(() => expect(fakeLivekitRoom.connect).toHaveBeenCalled());
+    const stopping = connection.stop();
+    pendingConnect.reject(new Error("Client initiated disconnect"));
+    await stopping;
+
+    // start() resolves rather than rejecting (it is not awaited by the
+    // ConnectionManager, so a rejection would be unhandled).
+    await expect(started).resolves.toBeUndefined();
+    expect(capturedStates.at(-1)).toEqual(ConnectionState.Stopped);
+    expect(capturedStates.some((st) => st instanceof Error)).toBe(false);
+  });
+
   it("shutting down the scope should stop the connection", async () => {
     setupTest();
     vi.useFakeTimers();

--- a/src/state/CallViewModel/remoteMembers/Connection.ts
+++ b/src/state/CallViewModel/remoteMembers/Connection.ts
@@ -258,6 +258,15 @@ export class Connection {
       // If we were stopped while connecting, don't proceed to update state.
       if (this.stopped) return;
     } catch (error) {
+      if (this.stopped) {
+        // stop() was called while we were connecting, which makes the pending
+        // connect reject. That is the abort we asked for, not a failure, so
+        // don't record an error state on a stopped connection or rethrow it
+        // (start() is not awaited by the ConnectionManager, so a throw here
+        // becomes an unhandled promise rejection).
+        this.logger.debug(`Connect aborted because the connection was stopped`);
+        return;
+      }
       this.logger.debug(`Failed to connect to LiveKit room: ${error}`);
       this._state$.next(
         error instanceof ElementCallError
@@ -296,9 +305,11 @@ export class Connection {
       `stop: disconnecing from lk room ${this.transport.livekit_service_url}`,
     );
     if (this.stopped) return;
+    // Mark as stopped before disconnecting so that a connect() aborted by the
+    // disconnect sees the flag and does not report the abort as an error.
+    this.stopped = true;
     await this.livekitRoom.disconnect();
     this._state$.next(ConnectionState.Stopped);
-    this.stopped = true;
     this.logger.debug(
       `stop: DONE disconnecing from lk room ${this.transport.livekit_service_url}`,
     );


### PR DESCRIPTION
This is another lowish priority Fable-generated PR to clean up logspam which otherwise fable chases when investigating rageshakes.

## Content

When a `Connection` is stopped while `livekitRoom.connect()` is still pending, livekit-client rejects the connect with `Client initiated disconnect`. `start()` treated that as a failure: it pushed an `UnknownCallError` into the state of an already-stopped connection and rethrew, and because `ConnectionManager` calls `void connection.start()` the throw became

```
Unhandled promise rejection: Error: Failed to connect to Livekit server
```

This fix marks the connection as stopped before disconnecting and makes `start()` return quietly when the rejection is the abort we asked for.

## Motivation and context

This shows up in essentially every rageshake, a few hundred milliseconds into joining: the local membership emits twice in quick succession, the connection set is recomputed, the first connection is torn down mid-connect and the replacement connects fine. The stack trace is noise that costs time in every log investigation (seen while triaging element-call-rageshakes 17153, 17219, 17226, 17233 this week) and it hides real connect failures.

## Tests

- New unit test: stop the connection while `connect()` is pending and check that `start()` resolves, the last state is `Stopped`, and no `Error` state was emitted. Fails without the fix.
- `pnpm vitest run --project=unit src/state/CallViewModel/remoteMembers` green.

## Checklist

- [x] A linked, pre-approved issue exists for this feature or UI change. (bug fix, no UI change)
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [x] Pull request includes screenshots or videos for any UI changes. (none)
- [x] Tests written for new code (and existing touched code where feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
