### PR TITLE
Don't attach the background blur processor to an ended camera track

### DIFF
--- a/src/livekit/TrackProcessorContext.test.ts
+++ b/src/livekit/TrackProcessorContext.test.ts
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { describe, expect, it, vi } from "vitest";
+import { type LocalVideoTrack } from "livekit-client";
+import {
+  type BackgroundOptions,
+  type ProcessorWrapper,
+} from "@livekit/track-processors";
+
+import { applyProcessor } from "./TrackProcessorContext";
+
+const processor = {} as ProcessorWrapper<BackgroundOptions>;
+
+function mockTrack(
+  readyState: MediaStreamTrackState,
+  current?: ProcessorWrapper<BackgroundOptions>,
+): LocalVideoTrack {
+  return {
+    mediaStreamTrack: { readyState },
+    getProcessor: vi.fn().mockReturnValue(current),
+    setProcessor: vi.fn().mockResolvedValue(undefined),
+    stopProcessor: vi.fn().mockResolvedValue(undefined),
+  } as unknown as LocalVideoTrack;
+}
+
+describe("applyProcessor", () => {
+  it("attaches the processor to a live track", () => {
+    const track = mockTrack("live");
+    applyProcessor(track, processor);
+    expect(track.setProcessor).toHaveBeenCalledWith(processor);
+  });
+
+  it("does not attach the processor to an ended track", () => {
+    const track = mockTrack("ended");
+    applyProcessor(track, processor);
+    expect(track.setProcessor).not.toHaveBeenCalled();
+  });
+
+  it("does not surface a rejected setProcessor", async () => {
+    const track = mockTrack("live");
+    vi.mocked(track.setProcessor).mockRejectedValue(
+      new TypeError("Input track cannot be ended"),
+    );
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    applyProcessor(track, processor);
+    await new Promise((r) => setTimeout(r, 0));
+    process.off("unhandledRejection", unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it("stops the processor when none is wanted", () => {
+    const track = mockTrack("live", processor);
+    applyProcessor(track, undefined);
+    expect(track.stopProcessor).toHaveBeenCalled();
+  });
+});

--- a/src/livekit/TrackProcessorContext.test.ts
+++ b/src/livekit/TrackProcessorContext.test.ts
@@ -14,7 +14,7 @@ import {
 
 import { applyProcessor, trackProcessorSync } from "./TrackProcessorContext";
 import { constant } from "../state/Behavior";
-import { testScope } from "../utils/test";
+import { flushPromises, testScope } from "../utils/test";
 
 const processor = {} as ProcessorWrapper<BackgroundOptions>;
 
@@ -51,7 +51,7 @@ describe("applyProcessor", () => {
     const unhandled = vi.fn();
     process.on("unhandledRejection", unhandled);
     applyProcessor(track, processor);
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     process.off("unhandledRejection", unhandled);
     expect(unhandled).not.toHaveBeenCalled();
   });
@@ -68,7 +68,7 @@ describe("applyProcessor", () => {
     const unhandled = vi.fn();
     process.on("unhandledRejection", unhandled);
     applyProcessor(track, undefined);
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     process.off("unhandledRejection", unhandled);
     expect(unhandled).not.toHaveBeenCalled();
   });

--- a/src/livekit/TrackProcessorContext.test.ts
+++ b/src/livekit/TrackProcessorContext.test.ts
@@ -12,7 +12,9 @@ import {
   type ProcessorWrapper,
 } from "@livekit/track-processors";
 
-import { applyProcessor } from "./TrackProcessorContext";
+import { applyProcessor, trackProcessorSync } from "./TrackProcessorContext";
+import { constant } from "../state/Behavior";
+import { testScope } from "../utils/test";
 
 const processor = {} as ProcessorWrapper<BackgroundOptions>;
 
@@ -58,5 +60,28 @@ describe("applyProcessor", () => {
     const track = mockTrack("live", processor);
     applyProcessor(track, undefined);
     expect(track.stopProcessor).toHaveBeenCalled();
+  });
+
+  it("does not surface a rejected stopProcessor", async () => {
+    const track = mockTrack("live", processor);
+    vi.mocked(track.stopProcessor).mockRejectedValue(new Error("nope"));
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    applyProcessor(track, undefined);
+    await new Promise((r) => setTimeout(r, 0));
+    process.off("unhandledRejection", unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+});
+
+describe("trackProcessorSync", () => {
+  it("applies the processor to the current track", () => {
+    const track = mockTrack("live");
+    trackProcessorSync(
+      testScope(),
+      constant(track),
+      constant({ supported: true, processor }),
+    );
+    expect(track.setProcessor).toHaveBeenCalledWith(processor);
   });
 });

--- a/src/livekit/TrackProcessorContext.tsx
+++ b/src/livekit/TrackProcessorContext.tsx
@@ -19,6 +19,7 @@ import {
   useMemo,
 } from "react";
 import { type LocalVideoTrack } from "livekit-client";
+import { logger } from "matrix-js-sdk/lib/logger";
 import { combineLatest, map, type Observable } from "rxjs";
 import { useObservable } from "observable-hooks";
 
@@ -66,6 +67,34 @@ export function useTrackProcessorObservable$(): Observable<ProcessorState> {
 }
 
 /**
+ * Attaches or detaches the processor so that the track matches the desired
+ * state, without throwing.
+ */
+export function applyProcessor(
+  videoTrack: LocalVideoTrack,
+  processor: ProcessorWrapper<BackgroundOptions> | undefined,
+): void {
+  if (processor && !videoTrack.getProcessor()) {
+    // A MediaStreamTrackProcessor cannot be constructed on an ended track
+    // (e.g. the camera was stopped while the processor was being applied),
+    // and setProcessor rejects with a TypeError. The track is going away
+    // anyway, so there is nothing to attach to.
+    if (videoTrack.mediaStreamTrack.readyState === "ended") {
+      logger.debug("Not attaching video processor to an ended track");
+      return;
+    }
+    videoTrack.setProcessor(processor).catch((e) => {
+      logger.warn("Failed to attach video processor", e);
+    });
+  }
+  if (!processor && videoTrack.getProcessor()) {
+    videoTrack.stopProcessor().catch((e) => {
+      logger.warn("Failed to stop video processor", e);
+    });
+  }
+}
+
+/**
  * Updates your video tracks to always use the given processor.
  */
 export const trackProcessorSync = (
@@ -78,13 +107,7 @@ export const trackProcessorSync = (
     .subscribe(([videoTrack, processorState]) => {
       if (!processorState) return;
       if (!videoTrack) return;
-      const { processor } = processorState;
-      if (processor && !videoTrack.getProcessor()) {
-        void videoTrack.setProcessor(processor);
-      }
-      if (!processor && videoTrack.getProcessor()) {
-        void videoTrack.stopProcessor();
-      }
+      applyProcessor(videoTrack, processorState.processor);
     });
 };
 
@@ -94,12 +117,7 @@ export const useTrackProcessorSync = (
   const { processor } = useTrackProcessor();
   useEffect(() => {
     if (!videoTrack) return;
-    if (processor && !videoTrack.getProcessor()) {
-      void videoTrack.setProcessor(processor);
-    }
-    if (!processor && videoTrack.getProcessor()) {
-      void videoTrack.stopProcessor();
-    }
+    applyProcessor(videoTrack, processor);
   }, [processor, videoTrack]);
 };
 


### PR DESCRIPTION
This is a lowish priority Fable-generated PR to go and remove logspam around rejected promises.

## Content

`trackProcessorSync` and `useTrackProcessorSync` called `videoTrack.setProcessor(processor)` with `void`. If the camera track has already ended, the blur processor's `MediaStreamTrackProcessor` cannot be constructed and the promise rejects, which surfaces as

```
Unhandled promise rejection: TypeError: Failed to construct 'MediaStreamTrackProcessor': Input track cannot be ended
```

Both call sites now go through one `applyProcessor` helper that skips tracks whose `mediaStreamTrack.readyState` is `ended` and catches and logs attach/detach failures.

## Motivation and context

Seen in element-call-rageshakes#17225 (Element Desktop, background blur on). Harmless to the user since the track was going away anyway, but it is an unhandled rejection at warning level that shows up when reading logs.

## Tests

- New `TrackProcessorContext.test.ts` covering: attaches to a live track, skips an ended track, a rejected `setProcessor` does not become an unhandled rejection, stops the processor when none is wanted.
- `pnpm lint` (tsc, oxlint, knip) clean.

## Checklist

- [x] A linked, pre-approved issue exists for this feature or UI change. (bug fix, no UI change)
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/main/CONTRIBUTING.md) in full.
- [x] Pull request includes screenshots or videos for any UI changes. (none)
- [x] Tests written for new code (and existing touched code where feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
