### PR TITLE
Queue re-entrant emissions in scope.behavior

### DIFF
--- a/src/state/ObservableScope.test.ts
+++ b/src/state/ObservableScope.test.ts
@@ -237,3 +237,32 @@ describe("Reconcile", () => {
     expect(setup).toHaveBeenCalledWith(1);
   });
 });
+
+describe("behavior", () => {
+  it("delivers a re-entrant emission to every subscriber, after the current one", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const scope = new ObservableScope();
+    const source$ = new Subject<number>();
+    const behavior$ = scope.behavior(source$, 0);
+    const seenFirst: number[] = [];
+    // A subscriber that reacts to the value 1 by synchronously emitting 2
+    behavior$.subscribe((v) => {
+      seenFirst.push(v);
+      if (v === 1) source$.next(2);
+    });
+    const seenSecond: number[] = [];
+    behavior$.subscribe((v) => seenSecond.push(v));
+
+    source$.next(1);
+
+    // Without queueing the second subscriber would be left on 1
+    expect(seenFirst).toEqual([0, 1, 2]);
+    expect(seenSecond).toEqual([0, 1, 2]);
+    expect(behavior$.value).toBe(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Behavior re-entered"),
+      expect.any(String),
+    );
+    scope.end();
+  });
+});

--- a/src/state/ObservableScope.ts
+++ b/src/state/ObservableScope.ts
@@ -20,6 +20,8 @@ import {
   takeUntil,
 } from "rxjs";
 
+import { logger } from "matrix-js-sdk/lib/logger";
+
 import { type Behavior } from "./Behavior";
 
 type MonoTypeOperator = <T>(o: Observable<T>) => Observable<T>;
@@ -73,9 +75,34 @@ export class ObservableScope {
     // they will no longer re-emit their current value upon subscription. We want
     // to support Observables that complete (for example `of({})`), so we have to
     // take care to not propagate the completion event.
+    // If a subscriber synchronously causes this same behavior to emit again,
+    // rxjs would deliver the nested value to every subscriber and then resume
+    // delivering the outer (older) value to the remaining subscribers, leaving
+    // them permanently out of sync. Queue nested emissions instead so that
+    // every subscriber sees every value, in order, and ends on the latest one.
+    const pending: T[] = [];
+    let delivering = false;
+    let reentryReported = false;
     setValue$.pipe(this.bind(), distinctUntilChanged()).subscribe({
       next(value) {
-        subject$.next(value);
+        pending.push(value);
+        if (delivering) {
+          if (!reentryReported) {
+            reentryReported = true;
+            logger.warn(
+              "Behavior re-entered while delivering a value; the nested value has been queued",
+              new Error().stack,
+            );
+          }
+          return;
+        }
+        delivering = true;
+        try {
+          while (pending.length > 0) subject$.next(pending.shift()!);
+        } finally {
+          delivering = false;
+          pending.length = 0;
+        }
       },
       error(err: unknown) {
         subject$.error(err);


### PR DESCRIPTION
## Content

`ObservableScope.behavior` now queues emissions that arrive while it is already delivering a value to its subscribers, so a synchronous re-entrant emission is delivered to every subscriber after the current one, in order. It also logs the first re-entry per behavior with a stack trace (the same warning as element-hq/element-call#4235) so remaining re-entrant paths can be found and cleaned up.

## Motivation and context

A `BehaviorSubject` walks its subscribers synchronously. If a subscriber synchronously causes the same subject to emit again, rxjs delivers the nested value to all subscribers first and then resumes delivering the outer, older value to the remaining subscribers. Those subscribers are left permanently on the stale value while `.value` holds the new one, and nothing re-emits afterwards.

Every EC view model is built on `scope.behavior`, and several derived behaviors read the same source (for a remote tile: media, speaking, video, waiting-for-media all derive from `participant$`). This hazard is the only mechanism found so far that explains a tile in element-hq/element-call-rageshakes#17279 that showed the speaking indicator (participant present) and "Waiting for media" (participant missing) at the same time.

The change is confined to the one primitive. The only observable difference is for the re-entrant emitter itself: its nested value is now delivered after the outer delivery completes rather than in the middle of it, which is the ordering every other subscriber already saw.

## Screenshots

N/A.

## Tests

`ObservableScope.test.ts` gains a test where a subscriber synchronously re-emits; it asserts that both subscribers see `[0, 1, 2]` and that the warning is logged. Without the queue the second subscriber ends on `1`. Full unit suite passes.

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.

## Checklist

- [ ] Pre-approved issue exists for this change.
- [x] PR has a `PR-*` label.
