### PR TITLE
Don't show the reconnecting overlay for signal-only reconnects

### DIFF
--- a/src/state/CallViewModel/localMember/LocalMember.test.ts
+++ b/src/state/CallViewModel/localMember/LocalMember.test.ts
@@ -930,6 +930,55 @@ describe("LocalMembership", () => {
       scope.end();
     });
 
+    it("ignores signal-only reconnects", async () => {
+      const scope = new ObservableScope();
+      const trackSpy = vi.spyOn(
+        PosthogAnalytics.instance.eventCallReconnecting,
+        "track",
+      );
+
+      const connectionState$ = new BehaviorSubject<ConnectionState>(
+        ConnectionState.LivekitConnected,
+      );
+      const mutableConnection = {
+        ...connectionTransportAConnected,
+        state$: connectionState$,
+      } as unknown as Connection;
+
+      const connectionManagerData = new ConnectionManagerData();
+      connectionManagerData.add(mutableConnection, []);
+
+      const localMembership = createLocalMembership$({
+        scope,
+        ...defaultCreateLocalMemberValues,
+        homeserverConnected: {
+          combined$: constant<[boolean, HomeserverDisconnectReason | null]>([
+            true,
+            null,
+          ]),
+          rtsSession$: constant(RTCMemberStatus.Connected),
+        },
+        connectionManager: {
+          connectionManagerData$: constant(new Epoch(connectionManagerData)),
+        },
+        localTransport: {
+          advertised$: constant(aTransport),
+          active$: constant(aTransportWithSFUConfig),
+        },
+      });
+
+      await flushPromises();
+
+      connectionState$.next(ConnectionState.LivekitSignalReconnecting);
+      expect(localMembership.reconnecting$.value).toBe(false);
+      expect(localMembership.connected$.value).toBe(true);
+      connectionState$.next(ConnectionState.LivekitConnected);
+
+      expect(trackSpy).not.toHaveBeenCalled();
+
+      scope.end();
+    });
+
     it("fires one event per completed reconnection cycle", async () => {
       const scope = new ObservableScope();
       const trackSpy = vi.spyOn(

--- a/src/state/CallViewModel/localMember/LocalMember.ts
+++ b/src/state/CallViewModel/localMember/LocalMember.ts
@@ -582,7 +582,13 @@ export const createLocalMembership$ = ({
     combineLatest([
       homeserverConnected.combined$,
       localConnectionState$.pipe(
-        map((state) => state === ConnectionState.LivekitConnected),
+        // A signal-only reconnect keeps the peer connection (and so the
+        // media) up, so we don't tell the user we're reconnecting for it.
+        map(
+          (state) =>
+            state === ConnectionState.LivekitConnected ||
+            state === ConnectionState.LivekitSignalReconnecting,
+        ),
       ),
     ]).pipe(
       map(([[hsConnected, hsReason], livekitConnected]) => {


### PR DESCRIPTION
### Content

`connectionDisconnectReason$` in `LocalMember` now treats `ConnectionState.LivekitSignalReconnecting` as connected, so `reconnecting$` (and hence `pretendToBeDisconnected$`, the reconnecting toast, the reconnect analytics event and the hands/reactions pause) only fires for a full `Reconnecting`, a disconnect, or a homeserver problem. `mediaState$` is unchanged.

### Motivation and context

When the SFU drops the signalling WebSocket (seen today across every client on an SFU during what looks like a rolling restart), livekit-client resumes the signal connection while the peer connection stays CONNECTED and media keeps flowing. EC nonetheless flipped `reconnecting$`, which zeroes playback volume on every remote tile, hides remote video and shows the non-dismissable "Reconnecting" overlay, so a 2s blip silenced the whole call. If the peer connection actually goes down livekit moves to `Reconnecting`, which still triggers the overlay as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KVLCMTTepFiHw7cBdA9e8