### PR TITLE
Audio quick menu: speakers, level meter and sound-effect volume in the microphone chevron

### DIFF
--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
@@ -1,0 +1,304 @@
+---
+status: implement
+blocked_from: null
+title: Audio quick menu
+owner: fkwp
+signoff:
+  eng: ok
+  design: ok
+  product: ok
+experiment_ref: fkwp/feature/audio_quick_menu_exploration
+base: 029622f07b44f58f8a84e7e167e5b66374479b63
+repos: [element-call]
+specs: []
+supersedes: []
+superseded_by: null
+---
+
+## Problem
+
+- `MediaMuteAndSwitchButton` populates its menu from `audioInput.available$` only. On
+  desktop, audio output is reachable only through `SettingsModal` → audio tab, which covers
+  the call view; the footer's `audioOutputSwitcher$` is an earpiece/loudspeaker toggle that
+  only materialises for controlled (mobile) devices.
+- No input-level indicator exists anywhere in the app: a participant cannot tell whether the
+  selected microphone captures sound without unmuting and asking another participant.
+- `soundEffectVolume` is adjustable only in `SettingsModal`, which replaces the call view.
+- `DeviceSelection` renders nothing when `available.size <= 1`, and `AudioOutput.available$`
+  is emptied on Safari, so those users get no indication of where call audio is going.
+- The in-call chevron is suppressed off desktop and in PiP via `disableDeviceSwitcher$`
+  (`CallFooterViewModel`), while `createLobbyFooterViewModel` passes `constant(false)`; the
+  two surfaces already disagree about when the menu exists.
+
+## Decisions
+
+- D1 — The level indicator captures from the microphone only while the menu is open, muted or
+  not — bounds the capture and the microphone-in-use indicator to a deliberate user action
+  while still answering "is my microphone working?" before unmuting.
+- D2 — The menu appears both before joining and during a call — pre-join is where a device
+  check matters most, in-call is where the settings detour costs most.
+- D3 — Before joining, the full menu appears on every platform, including mobile; during a
+  call it stays web/desktop only — the pre-join chevron already exists everywhere, so
+  suppressing sections there would be new work for no user gain.
+- D4 — Sound-effects volume appears in the menu and stays in settings, both reading and
+  writing one stored value — no migration, and neither audience loses the control it knows.
+- D5 — Where the audio output cannot be changed, the menu still shows the active output as a
+  non-selectable row — knowing where audio goes is useful even when it cannot be redirected.
+- D6 — The menu carries no disclosure that the microphone is sampled while muted — mute state
+  and the operating system's microphone-in-use indicator are independent of each other.
+- D7 — A microphone producing no signal shows an idle indicator; one held exclusively by
+  another application shows a greyed-out indicator — two distinguishable states, the second
+  rare on current operating systems.
+- D8 — A denied microphone permission shows a hint rather than a silent idle indicator —
+  silence is otherwise indistinguishable from a broken microphone.
+- D9 — The level indicator is focusable and announces its state to a screen reader while
+  focused — it is the one control in the menu with no non-visual equivalent.
+- D10 — No numeric latency target for the level indicator; it must move visibly while the
+  person is still speaking — perceived latency is not critical for a presence check.
+- D11 — Only the device lists scroll; the menu's heading and the sound-effect slider stay
+  in place — a list longer than the screen otherwise carries both out of view.
+- D12 — The level indicator belongs to the microphone group and stays visible while that
+  group is on screen, rather than sitting with the output controls — pinned next to the
+  sound-effect slider it reads as one of them.
+- D13 — Keyboard navigation marks the current item with a border, pointer use marks it with
+  a background and no border — the menu moves focus to whatever the pointer is over, so
+  without the distinction both appear at once.
+
+## Acceptance criteria
+
+Test names are the anchor; tests are created with exactly these names.
+
+- AC1 [FR-001] — The chevron beside the microphone button opens a menu headed "Audio controls".
+  - check: `pnpm vitest run --project=unit -t "audio menu is headed Audio controls"`
+- AC2 [FR-002] — The menu lists every available microphone, marks the active one, and selecting
+  another switches input without closing the menu.
+  - check: `pnpm vitest run --project=unit -t "audio menu switches microphone and stays open"`
+- AC3 [FR-003] — The menu lists every available audio output, marks the active one, and
+  selecting another switches output without closing the menu.
+  - check: `pnpm vitest run --project=unit -t "audio menu switches audio output and stays open"`
+- AC4 [FR-004] — The menu renders a separator between the microphone, speaker and
+  sound-effects groups.
+  - check: `pnpm vitest run --project=unit -t "audio menu separates microphone speaker and sound effects groups"`
+- AC5 [FR-005] — With exactly one audio output available, the speaker group still names the
+  active output and offers no selectable row.
+  - check: `pnpm vitest run --project=unit -t "audio menu shows single audio output as non-selectable"`
+- AC6 [FR-005] — In a browser that does not permit choosing an audio output, the speaker group
+  names the active output and offers no selectable row.
+  - check: manual, on Safari: join a call, open the microphone chevron, confirm the speaker
+    group names the output in use and that no row responds to a click.
+- AC7 [FR-006] — An output selected in the menu is shown as active in settings, and an output
+  selected in settings is shown as active in the menu.
+  - check: `pnpm vitest run --project=unit -t "audio output selection is shared between menu and settings"`
+- AC8 [FR-007] — While the menu is open, the level indicator's reported level follows the
+  signal level of the selected microphone.
+  - check: `pnpm vitest run --project=unit -t "level indicator follows the microphone signal level"`
+- AC9 [FR-008] — The level indicator responds to the microphone signal while the participant
+  is muted.
+  - check: `pnpm vitest run --project=unit -t "level indicator responds while muted"`
+- AC10 [FR-009] — Opening the menu starts capturing from the selected microphone; closing it
+  stops the capture.
+  - check: `pnpm vitest run --project=unit -t "audio menu starts capture on open and stops on close"`
+- AC11 [internal] — No microphone capture started by the menu outlives the menu, including
+  when the menu is closed while a device switch is in flight.
+  - check: `pnpm vitest run --project=unit -t "menu capture is released when closed during a device switch"`
+- AC12 [FR-010] — Selecting a different microphone re-points the level indicator at it without
+  closing the menu.
+  - check: `pnpm vitest run --project=unit -t "level indicator follows a microphone change"`
+- AC13 [FR-011] — A selected microphone that produces no signal leaves the indicator in its
+  idle state and produces no error.
+  - check: `pnpm vitest run --project=unit -t "level indicator stays idle for a silent microphone"`
+- AC14 [FR-018] — With microphone permission denied, the menu shows a hint in place of the
+  idle indicator.
+  - check: `pnpm vitest run --project=unit -t "audio menu hints when microphone permission is denied"`
+- AC15 [D7] — When the selected microphone cannot be opened because another application holds
+  it, the indicator renders in a greyed-out state.
+  - check: `pnpm vitest run --project=unit -t "level indicator greys out when the microphone is unavailable"`
+- AC16 [FR-012] — Moving the sound-effects slider changes the level at which the next sound
+  effect plays.
+  - check: `pnpm vitest run --project=unit -t "sound effects volume from the menu applies to the next effect"`
+- AC17 [FR-013] — Sound-effects volume set in the menu is shown in settings and vice versa.
+  - check: `pnpm vitest run --project=unit -t "sound effects volume is shared between menu and settings"`
+- AC18 [FR-014] — The full menu is present before joining on every platform, and during a call
+  on web and desktop.
+  - check: `pnpm vitest run --project=unit -t "audio menu is present pre-join on every platform"`
+- AC19 [FR-015] — During a call on mobile, the microphone chevron offers no menu.
+  - check: `pnpm test:playwright --project=mobile -g "no audio menu during a call on mobile"`
+- AC20 [FR-016] — Every control in the menu — device rows, level indicator and sound-effects
+  slider — is reachable and operable from the keyboard alone.
+  - check: `pnpm vitest run --project=unit -t "audio menu is fully operable from the keyboard"`
+- AC21 [FR-017] — The level indicator takes focus and announces its current state to a screen
+  reader while focused.
+  - check: manual, with VoiceOver active: open the menu, tab to the level indicator, speak,
+    confirm the announced state changes with the signal.
+- AC22 [D11] — With more devices than fit on screen, the heading and the sound-effect slider
+  stay visible while the device lists scroll.
+  - check: `pnpm vitest run --project=unit -t "audio menu keeps its title and volume slider out of the scrolling area"`
+- AC23 [D12] — The level indicator stays with the microphone list and never sits among the
+  output controls.
+  - check: `pnpm vitest run --project=unit -t "level indicator stays with the microphone list rather than the speakers"`
+- AC24 [D13] — Moving through the menu by keyboard marks the current item with a border;
+  moving over it with a pointer marks it with a background and no border.
+  - check: manual, open the menu and tab through the device rows, confirming a border marks
+    the focused row; then move the pointer across the rows, confirming a background appears
+    and no border does.
+- AC25 [SC-001] — Selecting an output from the menu during a call leaves the other
+  participants visible throughout.
+  - check: `pnpm test:playwright --project=chromium -g "audio menu leaves participants visible while switching output"`
+- AC26 [SC-002] — In a real browser with the menu open, sound at the microphone moves the
+  level indicator.
+  - check: `pnpm test:playwright --project=chromium --project=firefox -g "level indicator moves with microphone input"`
+- AC27 [SC-003] — Every menu control is reachable and operable by keyboard alone in
+  Chromium and Firefox.
+  - check: `pnpm test:playwright --project=chromium --project=firefox -g "audio menu is keyboard operable in a real browser"`
+
+## Rejected alternatives
+
+- Driving the level meter from the microphone track the call already publishes — the
+  track is muted exactly when the user is muted, so the meter reads flat in the one
+  situation it exists for (D1, FR-008). A capture of its own is what makes a muted
+  check possible.
+- Gating the audio menu on there being more than one microphone, as the chevron did
+  before — leaves no menu at all where there are no input devices to list but an
+  output section is still worth showing, which is the pre-join case on iOS (D3).
+- Naming the sound-effects slider with `aria-label` — the shared slider takes its
+  accessible name from its tooltip, so the label was overridden and the control
+  announced itself as "50%". The tooltip text now carries the control's name.
+- Bounding the height of the menu as a whole — keeps it on screen, but scrolls the
+  heading away with the device list, which is what the bound was meant to prevent (D11).
+- Pinning the level meter beside the sound-effect slider — always visible, but read as
+  one of the output controls rather than as a reading of the microphone (D12).
+- Letting the level meter scroll with the microphone list — on a machine with many
+  devices it is off screen for most of the interaction (D12).
+- Fixed-width meter bars spread across the row — all leftover width lands in the gaps,
+  so the bars read as thin lines separated by wide spaces. The bars share the row
+  instead, and the gap and bar count together set their thickness.
+
+## Measurements
+
+- Unit suite: ≥ 771 passing, 0 failing, ≥ 98 files (method: `pnpm vitest run --project=unit`
+  on the experiment branch rebased onto `base`, 2026-09-10; measured 771 / 0 / 98, 9 skipped).
+- SC-001: holds (method: manual, owner, 2026-09-10 — output switched from the microphone
+  chevron menu during a call; the other participants stayed visible throughout).
+- SC-002: holds (method: manual, owner, 2026-09-10 — menu open, speaking, muted and
+  unmuted; the level indicator moved while still speaking).
+- SC-003: holds (method: manual, owner, 2026-09-10 — every menu control reached and
+  operated by keyboard alone on the supported desktop browsers).
+- Not measured: what the meter's second concurrent capture costs alongside the call's own
+  — CPU of the second capture, analyser and per-frame poll during a call, and any glitch
+  on the call's own track when the capture opens or closes.
+
+## Out of scope
+
+- The in-call chevron on mobile (`platform` `android` / `ios`), which stays suppressed by
+  `disableDeviceSwitcher$` — FR-015. The lobby chevron is in scope on every platform
+  (FR-014), so whatever `audioOutput.available$` reports there — including the
+  speaker/earpiece entries of `AndroidControlledAudioOutput` / `IOSControlledAudioOutput` —
+  is rendered by the same menu.
+- The iOS native audio-device picker button (`showNativeAudioDevicePicker`); it stays in
+  `SettingsModal`.
+- The camera chevron menu and the background-blur toggle it carries.
+- PiP layout; the menu stays suppressed there.
+- An output test tone or "play test sound" affordance.
+- Noise suppression, echo cancellation and gain controls.
+- Restructuring the settings dialog beyond keeping the sound-effects slider in place.
+
+## Open questions
+
+None.
+
+## Slicing plan
+
+Re-derived 2026-09-10 against head 029622f (see Drift log). Owner decision 2026-09-10: the
+feature lands as one PR into `fkwp/feature/audio_quick_menu`, one commit per slice, each
+commit building and passing the unit suite on its own. Order follows story priority: US1
+(P1) first, US2 (P2) second, US3 (P3) third; FR-014's pre-join surface last. Both footers
+read one `MediaDevices` helper, so slice 1 lights the menu up on either surface and slice 5
+is what holds it there.
+
+1. Audio menu: "Audio controls" heading, microphone and speaker groups, active output as
+   a non-selectable row where it cannot be changed, outputs derived in
+   `CallFooterViewModel` — covers AC1, AC2, AC3, AC5, AC6, AC7, AC25 — depends on: none
+2. Level meter component and its capture hook, unused until slice 3 — covers AC8, AC11,
+   AC13, AC15 — depends on: none
+3. Level meter in the microphone group: capture bound to the menu being open, placement
+   with the microphone list, keyboard and pointer focus states — covers AC9, AC10, AC12,
+   AC14, AC23, AC24, AC26 — depends on: 1, 2
+4. Sound-effects volume in the menu, with only the device lists scrolling — covers AC4,
+   AC16, AC17, AC20, AC21, AC22, AC27 — depends on: 3
+5. Surface coverage: the menu reaches every platform before joining and stays gated to
+   desktop during a call — covers AC18, AC19 — depends on: 4
+
+## Drift log
+
+### 2026-09-10 — drift check (base 029622f → head 029622f)
+- `origin/main` is at `base`; `base..head` is empty. Every file and symbol named in
+  `## Problem`, `## Measurements` and the provisional slicing plan exists unchanged; no
+  decision is contradicted.
+- AC check commands: vitest project `unit` and playwright projects `chromium`, `firefox`
+  and `mobile` exist; every command runs.
+- Slicing plan re-derived on size and story priority, not on drift: the provisional
+  slice 2 (menu, speakers and meter, plus the `LobbyView` and `InCallView` snapshot
+  churn) exceeds the 800-line hard stop, and the P1 story (output selection) did not
+  lead. The pre-join surface moves to its own slice so the lobby snapshots change once.
+- Implementation base: `fkwp/feature/audio_quick_menu` = head + the repo agent contract
+  and the FEATURES_SPEC process, which are in review of their own. No source file differs
+  from head. The slices and this spec ride on one branch that opens a PR against it.
+
+### 2026-09-10 — owner decision: single PR
+- The five slices land as one PR with one commit per slice, at roughly 2000 changed lines.
+  Deviates from the 800-line hard stop in `FEATURES_SPEC/AGENTS.md` ("Turning a spec into
+  PRs", step 3); accepted by the owner for a feature of this size. Review is per commit.
+- The meter's capture cost stays unmeasured (see `## Measurements`): it needs a real-browser
+  CPU profile during a call, which the implementation environment cannot produce.
+
+### 2026-09-10 — implementation findings (head 029622f)
+- The level meter reads zero on Firefox in CI, and neither the test device nor the code is
+  the reason: Firefox's fake stream carries a 1 kHz tone at about a tenth of full scale,
+  and the same test drives the meter to 0.62 against Firefox off the runner, including
+  against the Docker image over plain HTTP that CI serves. The runner has no audio backend
+  for Firefox. AC26 is therefore skipped there, a deviation from its check.
+- Firefox starts an `AudioContext` suspended, which feeds the analyser silence until it
+  resumes of its own accord seconds later. The capture is now resumed on creation, so the
+  meter answers while the person is still speaking (D10).
+- AC27 is skipped on Firefox too, a deviation from its check, because headless Firefox
+  drives Tab unreliably, as `reconnect.spec.ts` records. AC25 skips Firefox, whose fake
+  stream enumerates no audio outputs and so has nothing to switch; its check names only
+  Chromium, so that is not a deviation.
+- Keyboard reach: the Radix menu swallows Tab and walks only its own items with the arrow
+  keys, so the meter and the slider were unreachable by keyboard alone. The audio menu
+  keeps Tab from the menu so the browser's focus order reaches them (AC20, AC27); the
+  exploration's keyboard test had only asserted that the controls exist.
+- Unit suite on the PR head: 99 files, 784 passing, 0 failing, 9 skipped (method:
+  `pnpm vitest run --project=unit`, 2026-09-10). The ≥ 771 / ≥ 98 floor holds.
+
+### 2026-09-10 — finding: menu taller than the viewport (AC22, D11)
+- With many devices the menu overflowed the viewport and carried the heading off the top:
+  its height bound applied to the content box, leaving the menu's own padding outside it.
+  Fixed by bounding the border box. AC22's check runs in jsdom, which lays nothing out, so
+  it passed throughout. The story `CallFooter › With Many Devices` now measures the layout
+  in a browser with the device count fixed; owner to decide whether AC22's check names it.
+  An e2e test cannot stand in for it, because how many devices overflow the menu depends on
+  how many a browser invents: the e2e test "audio menu stays inside a short window" asserts
+  only what holds at any device count.
+
+### 2026-09-10 — upstream PRs for the base of this branch
+- The repo agent contract and the FEATURES_SPEC process go to `main` on their own: #4256
+  (`fkwp/agents-md`) and #4255 (`fkwp/features-spec-process`). `fkwp/feature/audio_quick_menu`
+  carries both as if merged; rebasing it onto `main` after they land drops the duplicates.
+
+### 2026-09-10 — finding: chevron menus leave the root in the component build
+- Compound's `Menu` portals to `document.body`, and the component build rewrites every
+  selector to match only `[data-element-call-root]` or its descendants. A menu opened there
+  matches none of its own styles: no background, no border, no padding, and the audio menu's
+  height bound is inert, so nothing holds a long device list inside the window. Measured in
+  the component harness, which applies the same scoping the library build ships.
+- Not introduced by this feature. The camera chevron menu, untouched here, is equally
+  unstyled in that build, and no component test covers a menu, which is why it went unseen.
+- Out of scope for this spec: the fix is to give the portal the root element as its
+  container, which Compound does not expose today. Raised separately. The audio menu behaves
+  as specified standalone and as a widget, which is where its acceptance criteria are checked.
+
+## PRs
+
+- #4254 — draft, one commit per slice — AC1–AC27 (AC6, AC21, AC24 manual by the reviewer;
+  AC26, AC27 on Chromium only)

--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
@@ -150,6 +150,9 @@ Test names are the anchor; tests are created with exactly these names.
 - AC27 [SC-003] — Every menu control is reachable and operable by keyboard alone in
   Chromium and Firefox.
   - check: `pnpm test:playwright --project=chromium --project=firefox -g "audio menu is keyboard operable in a real browser"`
+- AC28 [review: #4254] — With no microphone present, the menu names the absence in place
+  of the level indicator, rather than an indicator at rest.
+  - check: `pnpm vitest run --project=unit -t "audio menu says when there is no microphone"`
 
 ## Rejected alternatives
 
@@ -297,6 +300,15 @@ is what holds it there.
 - Out of scope for this spec: the fix is to give the portal the root element as its
   container, which Compound does not expose today. Raised separately. The audio menu behaves
   as specified standalone and as a widget, which is where its acceptance criteria are checked.
+
+### 2026-09-11 — review finding: a missing microphone read as a silent one (#4254)
+- The product spec's edge case for no microphone mapped to no FR and so to no acceptance
+  criterion, and the menu drew a level indicator at rest, which is what a working but
+  silent microphone draws. The owner chose a hint in the indicator's place, as FR-018
+  requires for a denied permission, over omitting the microphone group entirely. The level
+  state now tells a microphone that is absent from one that is silent.
+- Added as AC28 and the product spec's edge case reworded to match, both with the owner's
+  authorisation, since acceptance criteria and the product spec are human-owned.
 
 ## PRs
 

--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
@@ -342,6 +342,14 @@ is what holds it there.
   remaining manual checks are AC6, which needs Safari, and AC21, which needs a screen
   reader.
 
+### 2026-09-11 — e2e tests must not assume how many devices a browser reports
+- Twice now a new e2e test has failed in CI for the same reason: how many devices a browser
+  invents differs between them and from a developer machine. Chromium reports several
+  microphones and outputs; Firefox in CI reports one microphone and no outputs, so the menu
+  holds a single selectable row. A test that hovered the second row timed out there.
+- Tests in `playwright/audio-menu.spec.ts` now assert only what holds at any device count.
+  Where a fixed device list is what makes the check meaningful, it belongs in a story.
+
 ## PRs
 
 - #4254 — draft, one commit per slice — AC1–AC27 (AC6, AC21, AC24 manual by the reviewer;

--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.md
@@ -112,7 +112,10 @@ Test names are the anchor; tests are created with exactly these names.
   - check: `pnpm vitest run --project=unit -t "audio menu hints when microphone permission is denied"`
 - AC15 [D7] — When the selected microphone cannot be opened because another application holds
   it, the indicator renders in a greyed-out state.
-  - check: `pnpm vitest run --project=unit -t "level indicator greys out when the microphone is unavailable"`
+  - check: `pnpm vitest run --project=storybook -t "Microphone Unavailable"`, which reads
+    the greying a browser applies. The unit test
+    `-t "level indicator greys out when the microphone is unavailable"` covers the state
+    the stylesheet keys off, and cannot fail on the greying itself.
 - AC16 [FR-012] — Moving the sound-effects slider changes the level at which the next sound
   effect plays.
   - check: `pnpm vitest run --project=unit -t "sound effects volume from the menu applies to the next effect"`
@@ -132,15 +135,17 @@ Test names are the anchor; tests are created with exactly these names.
     confirm the announced state changes with the signal.
 - AC22 [D11] — With more devices than fit on screen, the heading and the sound-effect slider
   stay visible while the device lists scroll.
-  - check: `pnpm vitest run --project=unit -t "audio menu keeps its title and volume slider out of the scrolling area"`
+  - check: `pnpm vitest run --project=storybook -t "With Many Devices"`, which measures the
+    layout in a browser with the device count fixed. The unit test
+    `-t "audio menu keeps its title and volume slider out of the scrolling area"` and the
+    e2e `-g "audio menu stays inside a short window"` cover the structure and the window
+    bound; neither can fail on layout alone.
 - AC23 [D12] — The level indicator stays with the microphone list and never sits among the
   output controls.
   - check: `pnpm vitest run --project=unit -t "level indicator stays with the microphone list rather than the speakers"`
 - AC24 [D13] — Moving through the menu by keyboard marks the current item with a border;
   moving over it with a pointer marks it with a background and no border.
-  - check: manual, open the menu and tab through the device rows, confirming a border marks
-    the focused row; then move the pointer across the rows, confirming a background appears
-    and no border does.
+  - check: `pnpm test:playwright --project=chromium --project=firefox -g "the focus border follows the keyboard and not the pointer"`
 - AC25 [SC-001] — Selecting an output from the menu during a call leaves the other
   participants visible throughout.
   - check: `pnpm test:playwright --project=chromium -g "audio menu leaves participants visible while switching output"`
@@ -309,6 +314,33 @@ is what holds it there.
   state now tells a microphone that is absent from one that is silent.
 - Added as AC28 and the product spec's edge case reworded to match, both with the owner's
   authorisation, since acceptance criteria and the product spec are human-owned.
+
+### 2026-09-11 — finding: `:focus-visible` cannot express D13 (#4254)
+- The menu moves focus onto whichever item the pointer is over, so the browser decides the
+  modality for a focus it did not see the user cause. Chromium calls every focus after any
+  key press keyboard-driven, so one Escape left the border following the mouse for the rest
+  of the session; Firefox never calls a programmatic focus keyboard-driven, so the border
+  never appeared there at all. Neither matches D13.
+- The menu now tracks which way each item was reached — a key press on the trigger or on an
+  item, against pointer movement over one — and the border follows that. Verified in both
+  browsers: the border appears only after a key press and leaves again on the next pointer
+  move. AC24's manual check could now name a unit test; owner's call.
+
+### 2026-09-11 — acceptance checks that could not fail (#4254)
+- Raised in review: AC22's check ran in jsdom, which lays nothing out, so it passed whatever
+  the layout did — the defect it exists for went unseen until a screenshot. Its check now
+  names the `CallFooter` "With Many Devices" story, which measures the geometry in a browser
+  with the device count fixed. The unit test and the short-window e2e stay as they are; the
+  criterion names the one that would fail.
+- AC24 was a manual check, and the border it describes turned out to be wrong in both
+  browsers for different reasons. Its check now names an e2e test that reads the painted
+  outline as the pointer and the keyboard take turns.
+- The same audit found AC15: its check asserted the attribute the stylesheet keys off, not
+  the greying, so losing the CSS rule would not have failed it. Re-anchored to the meter's
+  own story, which reads the applied opacity.
+- Every edit to `## Acceptance criteria` was made with the owner's authorisation. The
+  remaining manual checks are AC6, which needs Safari, and AC21, which needs a screen
+  reader.
 
 ## PRs
 

--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.notes.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.notes.md
@@ -1,0 +1,75 @@
+# Audio quick menu — exploration notes
+
+Not load-bearing. Nothing here constrains the implementation; constraints live in the
+feature spec.
+
+## Findings from the spike
+
+- **The shared slider names itself after its tooltip.** `Slider` wraps its thumb in a
+  compound `Tooltip`, which sets `aria-labelledby` on the thumb and so overrides the
+  `label` prop's `aria-label`. A screen reader announced the volume control as "50%".
+  Worked around at the call site by putting the control's name into the tooltip text.
+  The same defect exists in Settings → Audio today and would be better fixed in
+  `Slider` itself.
+- **Arrow keys inside the menu.** The radix menu treats arrow keys as navigation
+  between items, so a slider placed inside it never receives them. The slider row stops
+  propagation for arrow/Home/End. Without this the slider is mouse-only, which would
+  have failed AC20 silently.
+- **jsdom gaps.** The radix slider needs `ResizeObserver` and the meter needs
+  `AudioContext`; neither exists in jsdom, so both are stubbed per test file rather
+  than globally.
+- **Snapshot churn.** `LobbyView` and `InCallView` snapshots changed because the mic
+  button is now wrapped in the chevron container in cases that previously rendered a
+  bare button. Reviewed before updating; the change is the intended one.
+
+## Findings from design review
+
+- **An invented design token fails silently.** The meter's bars were written with
+  `--cpd-radius-pill-effective`; the token is `--cpd-radius-pill-effect`. An unknown
+  custom property makes the whole `border-radius` declaration invalid, so the bars
+  rendered square with no error anywhere. Worth grepping for the token name before
+  using one.
+- **A sticky child paints over the menu's border.** `FloatingMenu` draws its border as
+  an `outline` inset by one border width rather than as a real border. A
+  `position: sticky` child is positioned, so it paints above that outline and its
+  opaque background covered the border at the left and right edges. Fixed with a
+  matching inline margin on the sticky row.
+- **The bar geometry has two coupled knobs.** The bars share the row, so their width
+  is whatever the gaps leave over: raising the gap thins them and raising the count
+  thins them too. Moving both at once cancels out, which cost two review rounds.
+  Across the inset row (~248px at the menu's 340px maximum):
+
+  | bars | gap | bar width | bar:gap |
+  | ---- | --- | --------- | ------- |
+  | 20   | 8px | 4.8px     | 0.60    |
+  | 18   | 8px | 6.2px     | 0.78    |
+  | 17   | 8px | 7.1px     | 0.88    |
+  | 16   | 8px | 8.0px     | 1.00    |
+
+  The design sits near 0.8, hence 18 bars at an 8px gap.
+
+- **The bars line up with the label column, not the menu edge.** A menu item keeps a
+  `4x` margin after its label plus a `2x` column reserved for the chevron, on top of
+  the menu's own `4x` padding, so the meter's inline-end inset is `2 * 4x + 2x`.
+
+## Still open with design
+
+- The mockup marks the active device with a radio circle; the menu marks it with a
+  device icon and a checkmark, which is the existing pattern shared with the camera
+  chevron. Changing it would either change the camera menu too or make the two
+  inconsistent. Left as-is pending design sign-off.
+
+## Not done
+
+- Storybook interaction tests were not run; that project drives a real browser.
+  `AudioLevelMeter.stories.tsx` covers the five meter states for visual review.
+- Sticky positioning, the focus border and the bar geometry are all unverified by
+  tests: jsdom has no layout. The tests assert the DOM structure that makes them
+  possible, and the rest was checked by eye in a browser.
+- No measurement of what the meter's second capture costs while a call is running.
+  This is the main thing left before sign-off, and it is the decision most likely to
+  be revisited: if the cost is material, D1 gets narrower.
+- `oxfmt` covers markdown, and `AGENTS.md`, `_TEMPLATE.product.md` and the product
+  spec do not match its style, so `pnpm format:check` fails on them. Left alone: the
+  product spec is not editable after `draft` and the other two are process documents.
+  Either format them in a separate commit or exclude the folder from `oxfmt`.

--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.product.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.product.md
@@ -63,7 +63,7 @@ Join and leave chimes and reaction sounds are too loud during a call. The partic
 
 - The menu is opened while muted: the operating system's "microphone in use" indicator turns on even though the participant is muted. No disclosure in the menu is required — that indicator is expected to behave the same whether the participant is muted or not, and mute state and microphone sampling are independent of one another.
 - The active microphone or speaker is unplugged while the menu is open — the menu must settle on a device that exists rather than showing a stale selection.
-- No microphone is present at all: the microphone section and the level indicator have nothing to show.
+- No microphone is present at all: the menu says so where the level indicator would be. An indicator at rest is what a working but silent microphone shows, so the two must not look alike.
 - Microphone permission has not been granted yet — most likely when the menu is opened in the lobby before joining.
 - Another application or browser tab holds the microphone exclusively, so the level indicator receives no signal even though the device is fine. Rare on current operating systems, which share the microphone between applications; where it does happen, the indicator shows a greyed-out state.
 - Sound-effects volume is set to zero: effects are silent but the rest of the call audio is unaffected.

--- a/FEATURES_SPEC/2026-09_Audio_Quick_Menu.product.md
+++ b/FEATURES_SPEC/2026-09_Audio_Quick_Menu.product.md
@@ -1,0 +1,100 @@
+# Feature Specification: Audio quick menu
+
+**Feature Branch**: `[not yet created]`
+**Created**: 2026-09-09
+**Feature Spec**: `2026-09_Audio_Quick_Menu.md`  <!-- status lives in the feature spec's frontmatter, not here -->
+**Owner**: fkwp
+**Source**: this file
+**Input**: User description: "The chevron next to the mic button only offers microphone selection ('Mic Source'). Extend it into a combined audio quick-menu that also lets the user pick the speaker/output. Microphone check: the live, input-level meter that visibly reacts to the user's voice — so they immediately see the mic is active. For now this is web/desktop only (mobile is another story). Stretch: validate if it's possible to also place the sound effects volume in that new chevron menu."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Choose where the call is heard, without leaving the call (Priority: P1)
+
+A participant realises the call is coming out of the laptop speakers instead of their headset. They open the chevron next to the microphone button, see a speaker section alongside the microphone section, pick their headset, and hear the difference immediately — the call view never goes away and the menu stays open so they can confirm the choice.
+
+**Why this priority**: This is the change that removes a full detour through the settings dialog during a live call, and it is the reason the menu is being reshaped at all. It is valuable on its own, with no dependency on the level meter or the volume slider.
+
+**Independent Test**: With two or more audio outputs attached, join a call, open the microphone chevron, and switch output. Audio follows the choice, and the same choice is visible in settings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a participant in a call with two or more audio outputs available, **When** they open the microphone chevron, **Then** the menu shows a microphone section and a speaker section under one "Audio controls" heading, each marking the active device.
+2. **Given** the menu is open, **When** the participant selects a different speaker, **Then** call audio moves to that device, the row is marked active, and the menu stays open.
+3. **Given** the participant switched output from the menu, **When** they open settings, **Then** settings shows the same output as the active one.
+4. **Given** a browser that does not permit choosing an audio output, or a machine with exactly one output, **When** the participant opens the menu, **Then** the speaker section still shows which output is in use, presented as information rather than a choice.
+
+---
+
+### User Story 2 - Confirm the microphone is picking me up (Priority: P2)
+
+Before speaking — or after being told "we can't hear you" — a participant opens the same menu and speaks. A level indicator next to the microphone section moves with their voice, so they can tell within a second whether the selected microphone is live, and can try another one in the same menu if it is not.
+
+**Why this priority**: It answers the single most common audio complaint, but the menu is useful without it, and it carries the largest open design and privacy questions.
+
+**Independent Test**: Open the menu, speak, and watch the indicator move; select a different microphone in the same menu and confirm the indicator follows it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the menu is open and the participant is unmuted, **When** they speak, **Then** the indicator visibly rises and falls with their voice.
+2. **Given** the menu is open and the participant is muted, **When** they speak, **Then** the indicator still rises and falls, so they can verify the microphone before unmuting.
+3. **Given** the indicator is live, **When** the participant closes the menu, **Then** the indicator stops capturing from the microphone.
+4. **Given** the menu is open, **When** the participant selects a different microphone, **Then** the indicator follows the newly selected microphone and the menu stays open.
+5. **Given** the selected microphone produces no signal, **When** the participant speaks, **Then** the indicator rests in an idle state rather than showing an error.
+
+---
+
+### User Story 3 - Adjust sound-effect volume without leaving the call (Priority: P3)
+
+Join and leave chimes and reaction sounds are too loud during a call. The participant opens the audio menu and moves a sound-effects slider until the next chime sits where they want it.
+
+**Why this priority**: A convenience placement of an existing setting. It is the smallest slice, it can be dropped without touching the other two, and the value it adds is discoverability rather than new capability.
+
+**Independent Test**: Move the slider in the menu, trigger a sound effect, and confirm both the audible change and that settings shows the new value.
+
+**Acceptance Scenarios**:
+
+1. **Given** the menu is open, **When** the participant moves the sound-effects slider, **Then** the next sound effect plays at the new level.
+2. **Given** the participant changed the level in the menu, **When** they open settings, **Then** the settings slider shows the same level, and changing it there is reflected back in the menu.
+
+---
+
+### Edge Cases
+
+- The menu is opened while muted: the operating system's "microphone in use" indicator turns on even though the participant is muted. No disclosure in the menu is required — that indicator is expected to behave the same whether the participant is muted or not, and mute state and microphone sampling are independent of one another.
+- The active microphone or speaker is unplugged while the menu is open — the menu must settle on a device that exists rather than showing a stale selection.
+- No microphone is present at all: the microphone section and the level indicator have nothing to show.
+- Microphone permission has not been granted yet — most likely when the menu is opened in the lobby before joining.
+- Another application or browser tab holds the microphone exclusively, so the level indicator receives no signal even though the device is fine. Rare on current operating systems, which share the microphone between applications; where it does happen, the indicator shows a greyed-out state.
+- Sound-effects volume is set to zero: effects are silent but the rest of the call audio is unaffected.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The audio quick menu MUST be opened from the chevron next to the microphone button and MUST present its controls under a single "Audio controls" heading.
+- **FR-002**: The menu MUST list the available microphones, mark the active one, and switch input immediately on selection while staying open.
+- **FR-003**: The menu MUST list the available audio outputs, mark the active one, and switch output immediately on selection while staying open.
+- **FR-004**: The microphone, speaker and sound-effects controls MUST be visually separated from one another within the menu.
+- **FR-005**: When the audio output cannot be changed — the browser does not permit choosing an output, or only one output exists — the menu MUST still show the active output as a non-selectable row.
+- **FR-006**: The output selected in the menu and the output selected in settings MUST be one and the same selection; a change in either MUST be reflected in the other.
+- **FR-007**: The menu MUST show a live indicator of the sound level at the selected microphone.
+- **FR-008**: The indicator MUST respond while the microphone is muted as well as while it is unmuted.
+- **FR-009**: The indicator MUST become live when the menu opens and MUST stop capturing from the microphone when the menu closes.
+- **FR-010**: Selecting a different microphone MUST re-point the indicator at that microphone without closing the menu.
+- **FR-011**: When the selected microphone produces no signal, the indicator MUST show an idle state rather than an error.
+- **FR-012**: Users MUST be able to change the sound-effects volume from the menu, taking effect from the next sound effect onward.
+- **FR-013**: Sound-effects volume MUST remain adjustable in settings, and both controls MUST read and write the same stored value.
+- **FR-014**: The menu MUST be available before joining and during a call on web and desktop, and before joining on every platform — the pre-join chevron already exists everywhere and MUST show the full menu.
+- **FR-015**: During a call on mobile, the microphone chevron MUST behave as it does today; the menu is not introduced there.
+- **FR-016**: Every control in the menu MUST be reachable and operable by keyboard alone.
+- **FR-017**: The level indicator MUST be focusable, and while it holds focus it MUST announce its current state to a screen reader.
+- **FR-018**: When microphone permission has been denied, the menu MUST show a hint saying so, in place of a silent idle indicator.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Changing the audio output never requires opening a dialog that covers the call: the other participants remain visible from the moment the participant reaches for the control until the new output is in use.
+- **SC-002**: With the menu open, speech produces visible movement in the level indicator while the person is still speaking. No millisecond target: perceived latency is explicitly not critical for this indicator.
+- **SC-003**: Every control in the menu, including the sound-effects slider, is reachable and operable with the keyboard alone, verified on the supported desktop browsers.

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -23,6 +23,9 @@
     "upload_file": "Upload file"
   },
   "analytics_notice": "By participating in this beta, you consent to the collection of anonymous data, which we use to improve the product. You can find more information about which data we track in our <2>Privacy Policy</2> and our <6>Cookie Policy</6>.",
+  "audio_menu": {
+    "title": "Audio controls"
+  },
   "call_ended_view": {
     "create_account_button": "Create account",
     "create_account_prompt": "<0>Why not finish by setting up a password to keep your account?</0><1>You'll be able to keep your name and set an avatar for use on future calls</1>",

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -227,6 +227,7 @@
       "change_device_button": "Change audio device",
       "default": "Default",
       "default_named": "Default <2>({{name}})</2>",
+      "default_named_plain": "Default ({{name}})",
       "handset": "Handset",
       "loudspeaker": "Loudspeaker",
       "microphone": "Microphone",

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -24,6 +24,11 @@
   },
   "analytics_notice": "By participating in this beta, you consent to the collection of anonymous data, which we use to improve the product. You can find more information about which data we track in our <2>Privacy Policy</2> and our <6>Cookie Policy</6>.",
   "audio_menu": {
+    "mic_level_active": "Picking up sound",
+    "mic_level_label": "Microphone level",
+    "mic_level_silent": "No sound detected",
+    "mic_permission_denied": "Microphone access is blocked. Allow it in your browser settings.",
+    "mic_unavailable": "Microphone unavailable",
     "title": "Audio controls"
   },
   "call_ended_view": {

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -24,6 +24,7 @@
   },
   "analytics_notice": "By participating in this beta, you consent to the collection of anonymous data, which we use to improve the product. You can find more information about which data we track in our <2>Privacy Policy</2> and our <6>Cookie Policy</6>.",
   "audio_menu": {
+    "mic_absent": "No microphone found",
     "mic_level_active": "Picking up sound",
     "mic_level_label": "Microphone level",
     "mic_level_silent": "No sound detected",

--- a/playwright/audio-menu.spec.ts
+++ b/playwright/audio-menu.spec.ts
@@ -63,6 +63,33 @@ test("audio menu leaves participants visible while switching output", async ({
   await SpaHelpers.expectVideoTilesCount(page, 2);
 });
 
+test("level indicator moves with microphone input", async ({
+  browser,
+  browserName,
+}) => {
+  test.skip(
+    browserName === "firefox",
+    "Firefox has no audio backend on the CI runner, so the level stays at zero there. It passes against Firefox elsewhere, including CI's own Docker image over plain HTTP.",
+  );
+  const context = await browser.newContext({ reducedMotion: "reduce" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await SpaHelpers.createCall(page, "Speaker", "Level meter", true);
+  await expect(page.getByTestId("videoTile")).toHaveCount(1);
+
+  await page.getByRole("button", { name: "Microphone" }).click();
+  const meter = page.getByRole("menu").getByRole("meter");
+  await expect(meter).toBeVisible();
+
+  // The browser's fake microphone plays a tone, so the meter has to leave its
+  // resting level while the menu is open.
+  await expect
+    .poll(async () => Number(await meter.getAttribute("aria-valuenow")), {
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+});
+
 async function firstUncheckedIndex(
   rows: Locator,
   count: number,

--- a/playwright/audio-menu.spec.ts
+++ b/playwright/audio-menu.spec.ts
@@ -90,6 +90,88 @@ test("level indicator moves with microphone input", async ({
     .toBeGreaterThan(0);
 });
 
+test("audio menu is keyboard operable in a real browser", async ({
+  browser,
+  browserName,
+}) => {
+  test.skip(
+    browserName === "firefox",
+    'Firefox headless drives page.keyboard.press("Tab") unreliably, as reconnect.spec.ts records.',
+  );
+  const context = await browser.newContext({ reducedMotion: "reduce" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await SpaHelpers.createCall(page, "Keys", "Keyboard menu", true);
+  await expect(page.getByTestId("videoTile")).toHaveCount(1);
+
+  // Open from the chevron; the first device row takes focus.
+  await page.getByRole("button", { name: "Microphone" }).focus();
+  await page.keyboard.press("Enter");
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+  const rows = menu.getByRole("menuitemradio");
+  await expect(rows.first()).toBeFocused();
+
+  // Arrow keys walk the device rows, where the browser lists more than one.
+  if ((await rows.count()) > 1) {
+    await page.keyboard.press("ArrowDown");
+    await expect(rows.nth(1)).toBeFocused();
+  }
+
+  // Tab reaches the meter and then the slider; arrows adjust the slider and
+  // leave the menu open.
+  await page.keyboard.press("Tab");
+  await expect(menu.getByRole("meter")).toBeFocused();
+  await page.keyboard.press("Tab");
+  const slider = menu.getByRole("slider");
+  await expect(slider).toBeFocused();
+  const before = Number(await slider.getAttribute("aria-valuenow"));
+  await page.keyboard.press("ArrowRight");
+  await expect
+    .poll(async () => Number(await slider.getAttribute("aria-valuenow")))
+    .toBeGreaterThan(before);
+  await expect(menu).toBeVisible();
+
+  // Shift+Tab goes back; Escape closes.
+  await page.keyboard.press("Shift+Tab");
+  await expect(menu.getByRole("meter")).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(menu).not.toBeVisible();
+});
+
+test("audio menu stays inside a short window", async ({ browser }) => {
+  const context = await browser.newContext({
+    reducedMotion: "reduce",
+    viewport: { width: 1280, height: 560 },
+  });
+  const page = await context.newPage();
+  await page.goto("/");
+  await SpaHelpers.createCall(page, "Devices", "Long lists", true);
+  await page.getByTestId("videoTile").first().waitFor();
+
+  await page.getByRole("button", { name: "Microphone" }).focus();
+  await page.keyboard.press("Enter");
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+
+  // However many devices the browser reports, the menu fits the window and
+  // the heading and the slider are on screen with it. How many devices that
+  // is differs between browsers, so the case where the lists actually
+  // overflow is covered by the CallFooter "With Many Devices" story, which
+  // fixes the device count.
+  await expect(menu).toBeInViewport({ ratio: 1 });
+  await expect(
+    menu.getByRole("heading", { name: "Audio controls" }),
+  ).toBeInViewport({ ratio: 1 });
+  await expect(menu.getByRole("slider")).toBeInViewport({ ratio: 1 });
+
+  // The menu itself never becomes the scroller: that would carry the heading
+  // out of view, which is what the scroll area exists to prevent.
+  await expect
+    .poll(async () => menu.evaluate((el) => el.scrollHeight <= el.clientHeight))
+    .toBe(true);
+});
+
 async function firstUncheckedIndex(
   rows: Locator,
   count: number,

--- a/playwright/audio-menu.spec.ts
+++ b/playwright/audio-menu.spec.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { expect, type Locator, test } from "@playwright/test";
+
+import { SpaHelpers } from "./spa-helpers";
+
+test("audio menu leaves participants visible while switching output", async ({
+  browser,
+  browserName,
+}) => {
+  test.skip(
+    browserName === "firefox",
+    "Firefox's fake media stream enumerates no audio outputs, so there is nothing to switch.",
+  );
+
+  // Reduced motion disables the animations that make these tests flaky.
+  const creatorContext = await browser.newContext({ reducedMotion: "reduce" });
+  const page = await creatorContext.newPage();
+  await page.goto("/");
+  await SpaHelpers.createCall(page, "Inviter", "Audio menu", true);
+  const inviteLink = await SpaHelpers.getCallInviteLink(page);
+
+  const guestContext = await browser.newContext({ reducedMotion: "reduce" });
+  const guestPage = await guestContext.newPage();
+  await SpaHelpers.joinCallFromInviteLink(guestPage, inviteLink, "Guest");
+
+  await SpaHelpers.expectVideoTilesCount(page, 2);
+
+  // The chevron beside the microphone button opens the audio menu in place.
+  await page.getByRole("button", { name: "Microphone" }).click();
+  const menu = page.getByRole("menu");
+  await expect(
+    menu.getByRole("heading", { name: "Audio controls" }),
+  ).toBeVisible();
+
+  // Pick another output where the browser offers one; where it does not, the
+  // speaker group still names the output in use.
+  const outputs = menu
+    .getByTestId("audio_menu_scroll")
+    .locator('> [role="menuitemradio"]');
+  const count = await outputs.count();
+  if (count > 1) {
+    // Pinned by position: a locator on "the unchecked row" would re-resolve to
+    // the previously active row once the click has moved the check mark.
+    const other = outputs.nth(await firstUncheckedIndex(outputs, count));
+    await other.click();
+    await expect(other).toHaveAttribute("aria-checked", "true");
+    await expect(menu).toBeVisible();
+  } else {
+    await expect(menu.getByTestId("speaker_readonly")).toBeVisible();
+  }
+
+  // Nothing covered the call: the other participant is still on screen with
+  // the menu open, and after it closes.
+  await SpaHelpers.expectVideoTilesCount(page, 2);
+  await page.keyboard.press("Escape");
+  await expect(menu).not.toBeVisible();
+  await SpaHelpers.expectVideoTilesCount(page, 2);
+});
+
+async function firstUncheckedIndex(
+  rows: Locator,
+  count: number,
+): Promise<number> {
+  for (let i = 0; i < count; i++) {
+    if ((await rows.nth(i).getAttribute("aria-checked")) === "false") return i;
+  }
+  throw new Error("every output row is marked active");
+}

--- a/playwright/audio-menu.spec.ts
+++ b/playwright/audio-menu.spec.ts
@@ -181,8 +181,15 @@ test("the focus border follows the keyboard and not the pointer", async ({
   await SpaHelpers.createCall(page, "Focus", "Focus border", true);
   await page.getByTestId("videoTile").first().waitFor();
 
-  const chevron = page.getByRole("button", { name: "Microphone" });
-  const rows = page.getByRole("menu").getByRole("menuitemradio");
+  await page.getByRole("button", { name: "Microphone" }).click();
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+
+  // However many devices this browser reports, there is at least one row.
+  const row = menu.getByRole("menuitemradio").first();
+  const box = await row.boundingBox();
+  if (box === null) throw new Error("Expected the row to be laid out");
+  const centre = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
   const borderOfFocused = async (): Promise<string> =>
     page.evaluate(() => {
       const el = document.activeElement;
@@ -190,20 +197,19 @@ test("the focus border follows the keyboard and not the pointer", async ({
     });
 
   // Reached with the pointer: the hover background carries it, no border.
-  await chevron.click();
-  await page.getByRole("menu").waitFor();
-  await rows.nth(1).hover();
-  expect(await borderOfFocused()).toBe("none");
+  await page.mouse.move(centre.x, centre.y);
+  await expect.poll(borderOfFocused).toBe("none");
 
   // Reached with the keyboard: a border marks where the keyboard is. The menu
   // moves focus to whatever the pointer is over, so the browser cannot tell
   // these two apart on its own.
   await page.keyboard.press("ArrowDown");
-  expect(await borderOfFocused()).toBe("solid");
+  await expect.poll(borderOfFocused).toBe("solid");
 
-  // And back, on the next movement of the pointer.
-  await rows.nth(0).hover();
-  expect(await borderOfFocused()).toBe("none");
+  // And gone again on the next movement of the pointer. A point the pointer
+  // is not already at, so that the move is one.
+  await page.mouse.move(centre.x + 4, centre.y + 2);
+  await expect.poll(borderOfFocused).toBe("none");
 });
 
 async function firstUncheckedIndex(

--- a/playwright/audio-menu.spec.ts
+++ b/playwright/audio-menu.spec.ts
@@ -172,6 +172,40 @@ test("audio menu stays inside a short window", async ({ browser }) => {
     .toBe(true);
 });
 
+test("the focus border follows the keyboard and not the pointer", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ reducedMotion: "reduce" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await SpaHelpers.createCall(page, "Focus", "Focus border", true);
+  await page.getByTestId("videoTile").first().waitFor();
+
+  const chevron = page.getByRole("button", { name: "Microphone" });
+  const rows = page.getByRole("menu").getByRole("menuitemradio");
+  const borderOfFocused = async (): Promise<string> =>
+    page.evaluate(() => {
+      const el = document.activeElement;
+      return el === null ? "none" : getComputedStyle(el).outlineStyle;
+    });
+
+  // Reached with the pointer: the hover background carries it, no border.
+  await chevron.click();
+  await page.getByRole("menu").waitFor();
+  await rows.nth(1).hover();
+  expect(await borderOfFocused()).toBe("none");
+
+  // Reached with the keyboard: a border marks where the keyboard is. The menu
+  // moves focus to whatever the pointer is over, so the browser cannot tell
+  // these two apart on its own.
+  await page.keyboard.press("ArrowDown");
+  expect(await borderOfFocused()).toBe("solid");
+
+  // And back, on the next movement of the pointer.
+  await rows.nth(0).hover();
+  expect(await borderOfFocused()).toBe("none");
+});
+
 async function firstUncheckedIndex(
   rows: Locator,
   count: number,

--- a/playwright/mobile/audio-menu-mobile.spec.ts
+++ b/playwright/mobile/audio-menu-mobile.spec.ts
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { expect, test } from "@playwright/test";
+
+test("no audio menu during a call on mobile", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("home_callName").fill("Audio menu");
+  await page.getByTestId("home_displayName").fill("Mobile");
+  await page.getByTestId("home_go").click();
+  await expect(page.getByTestId("lobby_joinCall")).toBeVisible();
+
+  // Before joining, the microphone chevron exists and opens the full menu.
+  const chevron = page.getByRole("button", { name: "Microphone" });
+  await expect(chevron).toBeVisible();
+  await chevron.click();
+  // On mobile the menu is a drawer named after its title rather than headed
+  // by it.
+  const menu = page.getByRole("menu", { name: "Audio controls" });
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole("meter")).toBeVisible();
+  await expect(menu.getByRole("slider")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(menu).not.toBeVisible();
+
+  // During the call, the microphone button stands alone: no chevron, no menu.
+  await page.getByTestId("lobby_joinCall").click();
+  await expect(page.getByTestId("incall_mute")).toBeVisible();
+  await expect(page.getByTestId("incall_leave")).toBeVisible();
+  await expect(chevron).toHaveCount(0);
+});

--- a/src/components/AudioLevelMeter.module.css
+++ b/src/components/AudioLevelMeter.module.css
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+.meter {
+  display: flex;
+  align-items: center;
+  gap: var(--cpd-space-3x);
+  padding-block: var(--cpd-space-2x);
+  padding-inline-start: var(--cpd-space-4x);
+  /* Stop the bars where the device labels stop rather than at the menu edge:
+     a menu item keeps a 4x margin after its label plus a 2x column reserved
+     for the chevron, on top of the menu's own 4x padding. */
+  padding-inline-end: calc(2 * var(--cpd-space-4x) + var(--cpd-space-2x));
+  border-radius: var(--cpd-radius-pill-effect);
+}
+
+.meter:focus-visible {
+  outline: 2px solid var(--cpd-color-border-focused);
+  outline-offset: -2px;
+}
+
+.icon {
+  color: var(--cpd-color-icon-secondary);
+  flex-shrink: 0;
+}
+
+.bars {
+  display: flex;
+  align-items: center;
+  gap: var(--cpd-space-2x);
+  flex: 1;
+}
+
+.bar {
+  /* The bars share out whatever the gaps leave over, so the gap above and the
+     bar count together set how thick a bar is. Across the inset row that lands
+     near 6px per bar against the 8px gap, as in the design. */
+  flex: 1;
+  height: 20px;
+  border-radius: var(--cpd-radius-pill-effect);
+  background-color: var(--cpd-color-bg-subtle-primary);
+  transition: background-color 60ms linear;
+}
+
+.lit {
+  background-color: var(--cpd-color-icon-accent-primary);
+}
+
+.unavailable .icon,
+.unavailable .bar {
+  opacity: 0.5;
+}
+
+.message {
+  display: flex;
+  align-items: center;
+  gap: var(--cpd-space-3x);
+  padding-block: var(--cpd-space-2x);
+  padding-inline-start: var(--cpd-space-4x);
+  padding-inline-end: calc(2 * var(--cpd-space-4x) + var(--cpd-space-2x));
+  color: var(--cpd-color-text-secondary);
+  font: var(--cpd-font-body-sm-regular);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/src/components/AudioLevelMeter.stories.tsx
+++ b/src/components/AudioLevelMeter.stories.tsx
@@ -55,6 +55,15 @@ export const Unavailable: Story = {
   },
 };
 
+export const NoMicrophone: Story = {
+  args: { state: { type: "absent" } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole("meter")).toBe(null);
+    await expect(canvas.getByText(/No microphone found/)).toBeInTheDocument();
+  },
+};
+
 export const PermissionDenied: Story = {
   args: { state: { type: "denied" } },
   play: async ({ canvasElement }) => {

--- a/src/components/AudioLevelMeter.stories.tsx
+++ b/src/components/AudioLevelMeter.stories.tsx
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { expect, within } from "storybook/test";
+import { type JSX } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AudioLevelMeter } from "./AudioLevelMeter";
+
+const meta = {
+  component: AudioLevelMeter,
+  // The meter is only ever seen inside the audio menu, so give it a comparable
+  // width to judge the bar spacing against.
+  decorators: [
+    (Story): JSX.Element => (
+      <div style={{ width: 300 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AudioLevelMeter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Silent: Story = {
+  args: { state: { type: "active", level: 0 } },
+  play: async ({ canvasElement }) => {
+    const meter = within(canvasElement).getByRole("meter");
+    await expect(meter).toHaveAttribute("aria-valuetext", "No sound detected");
+  },
+};
+
+export const Speaking: Story = {
+  args: { state: { type: "active", level: 0.45 } },
+  play: async ({ canvasElement }) => {
+    const meter = within(canvasElement).getByRole("meter");
+    await expect(meter).toHaveAttribute("aria-valuetext", "Picking up sound");
+  },
+};
+
+export const Loud: Story = {
+  args: { state: { type: "active", level: 0.95 } },
+};
+
+export const Unavailable: Story = {
+  args: { state: { type: "unavailable" } },
+  play: async ({ canvasElement }) => {
+    const meter = within(canvasElement).getByRole("meter");
+    await expect(meter).toHaveAttribute("data-unavailable", "true");
+  },
+};
+
+export const PermissionDenied: Story = {
+  args: { state: { type: "denied" } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole("meter")).toBe(null);
+    await expect(
+      canvas.getByText(/Microphone access is blocked/),
+    ).toBeInTheDocument();
+  },
+};

--- a/src/components/AudioLevelMeter.stories.tsx
+++ b/src/components/AudioLevelMeter.stories.tsx
@@ -47,11 +47,16 @@ export const Loud: Story = {
   args: { state: { type: "active", level: 0.95 } },
 };
 
-export const Unavailable: Story = {
+/** Named apart from the footer's own "Unavailable Media Devices" story. */
+export const MicrophoneUnavailable: Story = {
   args: { state: { type: "unavailable" } },
   play: async ({ canvasElement }) => {
     const meter = within(canvasElement).getByRole("meter");
     await expect(meter).toHaveAttribute("data-unavailable", "true");
+    // The greying is the point, and it is done in CSS: an attribute alone
+    // would still be there with the rule gone.
+    const bar = meter.querySelector("span");
+    await expect(Number(getComputedStyle(bar!).opacity)).toBeLessThan(1);
   },
 };
 

--- a/src/components/AudioLevelMeter.test.tsx
+++ b/src/components/AudioLevelMeter.test.tsx
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AudioLevelMeter } from "./AudioLevelMeter";
+
+describe("AudioLevelMeter", () => {
+  test("a denied microphone renders a hint instead of the meter", () => {
+    render(<AudioLevelMeter state={{ type: "denied" }} />);
+    expect(screen.getByTestId("mic_level_denied")).toHaveTextContent(
+      /microphone access is blocked/i,
+    );
+    // A hint replaces the meter rather than sitting next to a dead one.
+    expect(screen.queryByRole("meter")).toBe(null);
+  });
+
+  test("level indicator greys out when the microphone is unavailable", () => {
+    render(<AudioLevelMeter state={{ type: "unavailable" }} />);
+    const meter = screen.getByRole("meter");
+    expect(meter).toHaveAttribute("data-unavailable", "true");
+    expect(meter).toHaveAttribute("aria-valuetext", "Microphone unavailable");
+  });
+
+  test("level indicator reports its level to assistive technology", () => {
+    const { rerender } = render(
+      <AudioLevelMeter state={{ type: "active", level: 0 }} />,
+    );
+    const meter = screen.getByRole("meter");
+    expect(meter).toHaveAttribute("aria-valuenow", "0");
+    expect(meter).toHaveAttribute("aria-valuetext", "No sound detected");
+
+    rerender(<AudioLevelMeter state={{ type: "active", level: 0.7 }} />);
+    expect(screen.getByRole("meter")).toHaveAttribute(
+      "aria-valuetext",
+      "Picking up sound",
+    );
+  });
+
+  test("level indicator announces its state only while focused", async () => {
+    const user = userEvent.setup();
+    render(<AudioLevelMeter state={{ type: "active", level: 0.7 }} />);
+    const meter = screen.getByRole("meter");
+
+    // Nothing is announced until the user puts the meter in focus, so the
+    // level does not talk over the rest of the menu.
+    expect(meter.textContent).not.toContain("Picking up sound");
+    await user.tab();
+    expect(meter).toHaveFocus();
+    expect(meter.textContent).toContain("Picking up sound");
+  });
+});

--- a/src/components/AudioLevelMeter.test.tsx
+++ b/src/components/AudioLevelMeter.test.tsx
@@ -12,6 +12,16 @@ import userEvent from "@testing-library/user-event";
 import { AudioLevelMeter } from "./AudioLevelMeter";
 
 describe("AudioLevelMeter", () => {
+  test("a missing microphone is named rather than drawn as silence", () => {
+    render(<AudioLevelMeter state={{ type: "absent" }} />);
+    expect(screen.getByTestId("mic_absent")).toHaveTextContent(
+      /no microphone found/i,
+    );
+    // Bars resting at zero would read as a microphone that hears nothing,
+    // which is a different thing and the one people act on.
+    expect(screen.queryByRole("meter")).toBe(null);
+  });
+
   test("a denied microphone renders a hint instead of the meter", () => {
     render(<AudioLevelMeter state={{ type: "denied" }} />);
     expect(screen.getByTestId("mic_level_denied")).toHaveTextContent(

--- a/src/components/AudioLevelMeter.test.tsx
+++ b/src/components/AudioLevelMeter.test.tsx
@@ -50,9 +50,13 @@ describe("AudioLevelMeter", () => {
 
     // Nothing is announced until the user puts the meter in focus, so the
     // level does not talk over the rest of the menu.
-    expect(meter.textContent).not.toContain("Picking up sound");
+    const announcer = meter.querySelector("[aria-live]");
+    expect(announcer).toHaveAttribute("aria-live", "off");
     await user.tab();
     expect(meter).toHaveFocus();
-    expect(meter.textContent).toContain("Picking up sound");
+    expect(announcer).toHaveAttribute("aria-live", "polite");
+    expect(announcer).toHaveTextContent("Picking up sound");
+    await user.tab();
+    expect(announcer).toHaveAttribute("aria-live", "off");
   });
 });

--- a/src/components/AudioLevelMeter.tsx
+++ b/src/components/AudioLevelMeter.tsx
@@ -43,6 +43,16 @@ export const AudioLevelMeter: FC<AudioLevelMeterProps> = ({ state }) => {
   const { t } = useTranslation();
   const [focused, setFocused] = useState(false);
 
+  // Bars resting at zero would read as a microphone that hears nothing, which
+  // is a different thing and the one people act on.
+  if (state.type === "absent")
+    return (
+      <div className={styles.message} data-testid="mic_absent">
+        <MicOffIcon width={24} height={24} aria-hidden />
+        <span>{t("audio_menu.mic_absent")}</span>
+      </div>
+    );
+
   if (state.type === "denied")
     return (
       <div className={styles.message} data-testid="mic_level_denied">

--- a/src/components/AudioLevelMeter.tsx
+++ b/src/components/AudioLevelMeter.tsx
@@ -14,10 +14,13 @@ import {
 import classNames from "classnames";
 
 import styles from "./AudioLevelMeter.module.css";
-import { type MicrophoneLevelState } from "./useMicrophoneLevel";
+import {
+  useMicrophoneLevel,
+  type MicrophoneLevelState,
+} from "./useMicrophoneLevel";
 
-// The bars share the row evenly, so the count is what sets their width: more
-// bars means thinner ones, and a finer-grained reading of the level.
+// The level is quantised into this many bars. They share the row, so the
+// count also sets how thick they are.
 const BAR_COUNT = 18;
 /**
  * Level below which the meter reads as silent. Above the noise floor of a
@@ -99,3 +102,22 @@ export const AudioLevelMeter: FC<AudioLevelMeterProps> = ({ state }) => {
     </div>
   );
 };
+
+export interface MicrophoneLevelProps {
+  /** The microphone to follow, or undefined if none is selected. */
+  deviceId: string | undefined;
+  /** Whether to hold a capture and report a level at all. */
+  active: boolean;
+}
+
+/**
+ * The level meter, following a microphone of its own.
+ *
+ * Re-renders when the level moves to another bar, and only itself.
+ */
+export const MicrophoneLevel: FC<MicrophoneLevelProps> = ({
+  deviceId,
+  active,
+}) => (
+  <AudioLevelMeter state={useMicrophoneLevel(deviceId, active, BAR_COUNT)} />
+);

--- a/src/components/AudioLevelMeter.tsx
+++ b/src/components/AudioLevelMeter.tsx
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { type FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  MicOnIcon,
+  MicOffIcon,
+} from "@vector-im/compound-design-tokens/assets/web/icons";
+import classNames from "classnames";
+
+import styles from "./AudioLevelMeter.module.css";
+import { type MicrophoneLevelState } from "./useMicrophoneLevel";
+
+// The bars share the row evenly, so the count is what sets their width: more
+// bars means thinner ones, and a finer-grained reading of the level.
+const BAR_COUNT = 18;
+/**
+ * Level below which the meter reads as silent. Above the noise floor of a
+ * typical desk microphone, so an idle room does not announce itself as sound.
+ */
+const SPEECH_THRESHOLD = 0.06;
+
+export interface AudioLevelMeterProps {
+  state: MicrophoneLevelState;
+}
+
+/**
+ * A live indicator of the signal level at the selected microphone.
+ *
+ * Focusable, so that a screen reader user can put it in focus and hear whether
+ * the microphone is picking anything up; the bars alone carry that information
+ * for everyone else.
+ */
+export const AudioLevelMeter: FC<AudioLevelMeterProps> = ({ state }) => {
+  const { t } = useTranslation();
+  const [focused, setFocused] = useState(false);
+
+  if (state.type === "denied")
+    return (
+      <div className={styles.message} data-testid="mic_level_denied">
+        <MicOffIcon width={24} height={24} aria-hidden />
+        <span>{t("audio_menu.mic_permission_denied")}</span>
+      </div>
+    );
+
+  const unavailable = state.type === "unavailable";
+  const level = state.type === "active" ? state.level : 0;
+  const litBars = unavailable ? 0 : Math.round(level * BAR_COUNT);
+  const speaking = !unavailable && level >= SPEECH_THRESHOLD;
+  const stateText = unavailable
+    ? t("audio_menu.mic_unavailable")
+    : speaking
+      ? t("audio_menu.mic_level_active")
+      : t("audio_menu.mic_level_silent");
+
+  return (
+    <div
+      className={classNames(styles.meter, {
+        [styles.unavailable]: unavailable,
+      })}
+      data-testid="mic_level_meter"
+      data-unavailable={unavailable || undefined}
+      role="meter"
+      // The meter is the only place the "is my microphone working?" answer
+      // lives, so it has to be reachable without a pointer even though a
+      // meter is not an interactive control.
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={0}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      aria-label={t("audio_menu.mic_level_label")}
+      aria-valuemin={0}
+      aria-valuemax={1}
+      aria-valuenow={level}
+      aria-valuetext={stateText}
+    >
+      <MicOnIcon width={24} height={24} className={styles.icon} aria-hidden />
+      <div className={styles.bars}>
+        {Array.from({ length: BAR_COUNT }, (_, i) => (
+          <span
+            key={i}
+            className={classNames(styles.bar, { [styles.lit]: i < litBars })}
+          />
+        ))}
+      </div>
+      {/* Only announces while the meter holds focus, so the level does not
+          interrupt a screen reader reading the rest of the menu. */}
+      <span className={styles.srOnly} aria-live="polite">
+        {focused ? stateText : ""}
+      </span>
+    </div>
+  );
+};

--- a/src/components/AudioLevelMeter.tsx
+++ b/src/components/AudioLevelMeter.tsx
@@ -88,10 +88,13 @@ export const AudioLevelMeter: FC<AudioLevelMeterProps> = ({ state }) => {
           />
         ))}
       </div>
-      {/* Only announces while the meter holds focus, so the level does not
-          interrupt a screen reader reading the rest of the menu. */}
-      <span className={styles.srOnly} aria-live="polite">
-        {focused ? stateText : ""}
+      {/* Announces changes only while the meter holds focus, so the level does
+          not talk over a screen reader reading the rest of the menu. The text
+          stays in the DOM either way: removing it on blur would hand the
+          menu's focus trap an empty active element mid-Tab, and it would pull
+          focus back into the menu instead of letting it reach the slider. */}
+      <span className={styles.srOnly} aria-live={focused ? "polite" : "off"}>
+        {stateText}
       </span>
     </div>
   );

--- a/src/components/CallFooter.stories.tsx
+++ b/src/components/CallFooter.stories.tsx
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
 import { BehaviorSubject } from "rxjs";
 import { type JSX, type ReactNode } from "react";
 import { Link } from "@vector-im/compound-web";
@@ -103,6 +103,7 @@ const meta = {
     toggleAudio: fnArgType,
     toggleVideo: fnArgType,
     hangup: fnArgType,
+    selectAudioOutputOption: fnArgType,
   },
 } satisfies Meta<typeof CallFooterStoryWrapper>;
 
@@ -142,6 +143,9 @@ export const Default: Story = {
     selectedVideo: undefined,
     selectAudioButtonOption: undefined,
     selectVideoButtonOption: undefined,
+    audioOutputOptions: [],
+    selectedAudioOutput: undefined,
+    selectAudioOutputOption: undefined,
   },
   parameters: {
     layout: "fullscreen",
@@ -413,5 +417,68 @@ export const LobbyRecentButtonMobile: Story = {
   },
   parameters: {
     ...Default.parameters,
+  },
+};
+
+/** The microphone chevron opens the audio menu: microphones and speakers. */
+export const WithAudioMenu: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    audioEnabled: true,
+    audioOptions: [
+      { label: { type: "name", name: "MacBook Pro Microphone" }, id: "1" },
+      { label: { type: "name", name: "Jabra Evolve 65" }, id: "2" },
+    ],
+    selectedAudio: "1",
+    selectAudioButtonOption: fn(),
+    audioOutputOptions: [
+      { label: { type: "default", name: "MacBook Pro Speakers" }, id: "" },
+      { label: { type: "name", name: "Jabra Evolve 65" }, id: "2" },
+    ],
+    selectedAudioOutput: "",
+    selectAudioOutputOption: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Microphone" }));
+
+    const menu = within(await screen.findByRole("menu"));
+    await expect(
+      menu.getByRole("heading", { name: "Audio controls" }),
+    ).toBeInTheDocument();
+    // The headset appears in both groups under the same name, as a real one
+    // does. The speaker rows are the scroll area's own children; the
+    // microphone rows sit one level deeper, inside their group.
+    const scroll = menu.getByTestId("audio_menu_scroll");
+    const outputs = [...scroll.children].filter(
+      (el) => el.getAttribute("role") === "menuitemradio",
+    );
+    await userEvent.click(outputs[1]);
+    await expect(args.selectAudioOutputOption).toHaveBeenCalledWith("2");
+    // The menu stays open after a selection.
+    await expect(screen.getByRole("menu")).toBeInTheDocument();
+  },
+};
+
+/** One output only: the speaker group names it without offering a choice. */
+export const WithSingleAudioOutput: Story = {
+  ...WithAudioMenu,
+  args: {
+    ...WithAudioMenu.args,
+    audioOutputOptions: [
+      { label: { type: "default", name: "MacBook Pro Speakers" }, id: "" },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Microphone" }));
+
+    await expect(
+      await screen.findByTestId("speaker_readonly"),
+    ).toHaveTextContent("MacBook Pro Speakers");
+    await expect(
+      screen.queryByRole("menuitemradio", { name: /Speakers/ }),
+    ).toBe(null);
   },
 };

--- a/src/components/CallFooter.stories.tsx
+++ b/src/components/CallFooter.stories.tsx
@@ -361,10 +361,29 @@ export const MobileLayout: Story = {
   },
 };
 
+/** Devices and controls of the audio menu, as the lobby offers them. */
+const audioMenuArgs = {
+  audioOptions: [
+    { label: { type: "name", name: "MacBook Pro Microphone" }, id: "1" },
+    { label: { type: "name", name: "Jabra Evolve 65" }, id: "2" },
+  ],
+  selectedAudio: "1",
+  selectAudioButtonOption: fn(),
+  audioOutputOptions: [
+    { label: { type: "default", name: "MacBook Pro Speakers" }, id: "" },
+    { label: { type: "name", name: "Jabra Evolve 65" }, id: "2" },
+  ],
+  selectedAudioOutput: "",
+  selectAudioOutputOption: fn(),
+  soundEffectVolume: 0.5,
+  setSoundEffectVolume: fn(),
+} satisfies Partial<FooterSnapshot>;
+
 export const Lobby: Story = {
   ...Default,
   args: {
     ...Default.args,
+    ...audioMenuArgs,
     showLogo: false,
     openSettings: undefined,
     layout: null,
@@ -379,6 +398,7 @@ export const LobbyMobile: Story = {
   ...Default,
   args: {
     ...Default.args,
+    ...audioMenuArgs,
     showLogo: false,
 
     layout: null,
@@ -429,19 +449,7 @@ export const WithAudioMenu: Story = {
   args: {
     ...Default.args,
     audioEnabled: true,
-    audioOptions: [
-      { label: { type: "name", name: "MacBook Pro Microphone" }, id: "1" },
-      { label: { type: "name", name: "Jabra Evolve 65" }, id: "2" },
-    ],
-    selectedAudio: "1",
-    selectAudioButtonOption: fn(),
-    audioOutputOptions: [
-      { label: { type: "default", name: "MacBook Pro Speakers" }, id: "" },
-      { label: { type: "name", name: "Jabra Evolve 65" }, id: "2" },
-    ],
-    selectedAudioOutput: "",
-    selectAudioOutputOption: fn(),
-    setSoundEffectVolume: fn(),
+    ...audioMenuArgs,
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/CallFooter.stories.tsx
+++ b/src/components/CallFooter.stories.tsx
@@ -104,6 +104,7 @@ const meta = {
     toggleVideo: fnArgType,
     hangup: fnArgType,
     selectAudioOutputOption: fnArgType,
+    setSoundEffectVolume: fnArgType,
   },
 } satisfies Meta<typeof CallFooterStoryWrapper>;
 
@@ -146,6 +147,8 @@ export const Default: Story = {
     audioOutputOptions: [],
     selectedAudioOutput: undefined,
     selectAudioOutputOption: undefined,
+    soundEffectVolume: 0.5,
+    setSoundEffectVolume: undefined,
   },
   parameters: {
     layout: "fullscreen",
@@ -438,6 +441,7 @@ export const WithAudioMenu: Story = {
     ],
     selectedAudioOutput: "",
     selectAudioOutputOption: fn(),
+    setSoundEffectVolume: fn(),
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
@@ -458,6 +462,9 @@ export const WithAudioMenu: Story = {
     await expect(args.selectAudioOutputOption).toHaveBeenCalledWith("2");
     // The menu stays open after a selection.
     await expect(screen.getByRole("menu")).toBeInTheDocument();
+    await expect(
+      menu.getByRole("slider", { name: /Sound effect volume/ }),
+    ).toBeInTheDocument();
   },
 };
 
@@ -480,5 +487,52 @@ export const WithSingleAudioOutput: Story = {
     await expect(
       screen.queryByRole("menuitemradio", { name: /Speakers/ }),
     ).toBe(null);
+  },
+};
+
+/**
+ * More devices than fit on screen: the heading and the slider stay put while
+ * the device lists scroll between them.
+ */
+export const WithManyDevices: Story = {
+  ...WithAudioMenu,
+  args: {
+    ...WithAudioMenu.args,
+    audioOptions: Array.from({ length: 12 }, (_, i) => ({
+      label: { type: "name", name: `Microphone ${i + 1} (USB Audio Device)` },
+      id: `mic-${i}`,
+    })),
+    selectedAudio: "mic-0",
+    audioOutputOptions: Array.from({ length: 8 }, (_, i) => ({
+      label: { type: "name", name: `Speaker ${i + 1} (DisplayPort)` },
+      id: `out-${i}`,
+    })),
+    selectedAudioOutput: "out-0",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Microphone" }));
+    const menu = await screen.findByRole("menu");
+    const heading = within(menu).getByRole("heading", {
+      name: "Audio controls",
+    });
+    const slider = within(menu).getByRole("slider");
+    const scroll = within(menu).getByTestId("audio_menu_scroll");
+
+    // The menu slides in; measure once it has settled.
+    await Promise.all(
+      menu.getAnimations({ subtree: true }).map(async (a) => a.finished),
+    );
+
+    // The whole menu is on screen, so the heading and the slider are too.
+    const menuBox = menu.getBoundingClientRect();
+    await expect(menuBox.top).toBeGreaterThanOrEqual(0);
+    await expect(menuBox.bottom).toBeLessThanOrEqual(window.innerHeight);
+    await expect(heading.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+    await expect(slider.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      window.innerHeight,
+    );
+    // Only the device lists scroll.
+    await expect(scroll.scrollHeight).toBeGreaterThan(scroll.clientHeight);
   },
 };

--- a/src/components/CallFooter.test.tsx
+++ b/src/components/CallFooter.test.tsx
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BehaviorSubject } from "rxjs";
+import { Root as Form, TooltipProvider } from "@vector-im/compound-web";
+import { type ReactNode } from "react";
+
+import { CallFooter } from "./CallFooter";
+import { DeviceSelection } from "../settings/DeviceSelection";
+import { MediaDevicesContext } from "../MediaDevicesContext";
+import { ReactionsSenderContext } from "../reactions/useReactionsSender";
+import {
+  type AudioOutputDeviceLabel,
+  type MediaDevices,
+  type SelectedAudioOutputDevice,
+} from "../state/MediaDevices";
+import { constant } from "../state/Behavior";
+import { mockMediaDevices } from "../utils/test";
+import { getBasicCallViewModelEnvironment } from "../utils/test-viewmodel";
+import { alice, local } from "../utils/test-fixtures";
+
+describe("CallFooter", () => {
+  test("audio menu is headed Audio controls", async () => {
+    const user = userEvent.setup();
+    renderFooter(mediaDevicesWithOutputs());
+
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+
+    const menu = await screen.findByRole("menu");
+    expect(
+      within(menu).getByRole("heading", { name: "Audio controls" }),
+    ).toBeInTheDocument();
+  });
+
+  test("audio output selection is shared between menu and settings", async () => {
+    const user = userEvent.setup();
+    const mediaDevices = mediaDevicesWithOutputs();
+    renderFooter(
+      mediaDevices,
+      <Form>
+        <DeviceSelection
+          device={mediaDevices.audioOutput}
+          title="Speaker"
+          numberedLabel={(n) => `Speaker ${n}`}
+        />
+      </Form>,
+    );
+
+    // Chosen in the menu, shown in settings. The open menu hides the rest of
+    // the page from assistive technology, so it closes before settings is read.
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: "Headset" }),
+    );
+    await user.keyboard("[Escape]");
+    expect(screen.getByRole("radio", { name: "Headset" })).toBeChecked();
+
+    // Chosen in settings, shown in the menu.
+    await user.click(screen.getByRole("radio", { name: "Built-in Speakers" }));
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    expect(
+      await screen.findByRole("menuitemradio", { name: "Built-in Speakers" }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("menuitemradio", { name: "Headset" }),
+    ).toHaveAttribute("aria-checked", "false");
+  });
+
+  /** The in-call footer over its real view model, with settings beside it. */
+  function renderFooter(
+    mediaDevices: MediaDevices,
+    settings?: ReactNode,
+  ): void {
+    const { footerVm } = getBasicCallViewModelEnvironment(
+      [local, alice],
+      undefined,
+      mediaDevices,
+    );
+    render(
+      <TooltipProvider>
+        <MediaDevicesContext value={mediaDevices}>
+          <ReactionsSenderContext
+            value={{
+              supportsReactions: false,
+              toggleRaisedHand: async (): Promise<void> => Promise.resolve(),
+              sendReaction: async (): Promise<void> => Promise.resolve(),
+            }}
+          >
+            <CallFooter vm={footerVm} />
+            {settings}
+          </ReactionsSenderContext>
+        </MediaDevicesContext>
+      </TooltipProvider>,
+    );
+  }
+
+  /** Two outputs whose selection is one shared value, as in MediaDevices. */
+  function mediaDevicesWithOutputs(): MediaDevices {
+    const selected$ = new BehaviorSubject<
+      SelectedAudioOutputDevice | undefined
+    >({ id: "out-1", virtualEarpiece: false });
+    return mockMediaDevices({
+      requestDeviceNames: vi.fn(),
+      audioOutput: {
+        available$: constant(
+          new Map<string, AudioOutputDeviceLabel>([
+            ["out-1", { type: "name", name: "Built-in Speakers" }],
+            ["out-2", { type: "name", name: "Headset" }],
+          ]),
+        ),
+        selected$,
+        select: (id: string): void =>
+          selected$.next({ id, virtualEarpiece: false }),
+      },
+    });
+  }
+});

--- a/src/components/CallFooter.test.tsx
+++ b/src/components/CallFooter.test.tsx
@@ -5,12 +5,12 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BehaviorSubject } from "rxjs";
 import { Root as Form, TooltipProvider } from "@vector-im/compound-web";
-import { type ReactNode } from "react";
+import { type JSX, type ReactNode } from "react";
 
 import { CallFooter } from "./CallFooter";
 import { DeviceSelection } from "../settings/DeviceSelection";
@@ -23,10 +23,54 @@ import {
 } from "../state/MediaDevices";
 import { constant } from "../state/Behavior";
 import { mockMediaDevices } from "../utils/test";
+import {
+  soundEffectVolume as soundEffectVolumeSetting,
+  useSetting,
+} from "../settings/settings";
 import { getBasicCallViewModelEnvironment } from "../utils/test-viewmodel";
 import { alice, local } from "../utils/test-fixtures";
 
 describe("CallFooter", () => {
+  afterEach(() => soundEffectVolumeSetting.setValue(0.5));
+
+  test("sound effects volume from the menu applies to the next effect", async () => {
+    const user = userEvent.setup();
+    renderFooter(mediaDevicesWithOutputs());
+
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    await screen.findByRole("menu");
+    await user.keyboard("[ArrowDown]");
+    await user.tab();
+    await user.tab();
+    await user.keyboard("[ArrowRight]");
+
+    // The committed value lands in the setting the sound-effect player reads,
+    // so the next effect plays at the new level.
+    expect(soundEffectVolumeSetting.value$.value).toBe(0.51);
+  });
+
+  test("sound effects volume is shared between menu and settings", async () => {
+    const user = userEvent.setup();
+    renderFooter(mediaDevicesWithOutputs(), <SettingsVolume />);
+
+    // Set from the menu, shown in settings.
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    await screen.findByRole("menu");
+    await user.keyboard("[ArrowDown]");
+    await user.tab();
+    await user.tab();
+    await user.keyboard("[ArrowRight]");
+    await user.keyboard("[Escape]");
+    expect(screen.getByRole("status")).toHaveTextContent("51%");
+
+    // Set from settings, shown in the menu.
+    await user.click(screen.getByRole("button", { name: "Set to 20%" }));
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    expect(
+      await screen.findByRole("slider", { name: /Sound effect volume/ }),
+    ).toHaveAttribute("aria-valuenow", "0.2");
+  });
+
   test("audio menu is headed Audio controls", async () => {
     const user = userEvent.setup();
     renderFooter(mediaDevicesWithOutputs());
@@ -98,6 +142,17 @@ describe("CallFooter", () => {
           </ReactionsSenderContext>
         </MediaDevicesContext>
       </TooltipProvider>,
+    );
+  }
+
+  /** Reads and writes the volume the way the settings dialog does. */
+  function SettingsVolume(): JSX.Element {
+    const [volume, setVolume] = useSetting(soundEffectVolumeSetting);
+    return (
+      <>
+        <output>{Math.round(volume * 100)}%</output>
+        <button onClick={() => setVolume(0.2)}>Set to 20%</button>
+      </>
     );
   }
 

--- a/src/components/CallFooter.tsx
+++ b/src/components/CallFooter.tsx
@@ -116,6 +116,9 @@ export interface FooterState {
   selectedAudioOutput: string | undefined;
   /** Also controls whether the microphone chevron opens the audio menu */
   selectAudioOutputOption: ((deviceId: string) => void) | undefined;
+  soundEffectVolume: number;
+  /** Also controls whether the microphone chevron opens the audio menu */
+  setSoundEffectVolume: ((volume: number) => void) | undefined;
 }
 
 export interface FooterProps {
@@ -159,6 +162,8 @@ export const CallFooter: FC<FooterProps> = ({
   const audioOutputOptions = useBehavior(vm.audioOutputOptions$);
   const selectedAudioOutput = useBehavior(vm.selectedAudioOutput$);
   const selectAudioOutputOption = useBehavior(vm.selectAudioOutputOption$);
+  const soundEffectVolume = useBehavior(vm.soundEffectVolume$);
+  const setSoundEffectVolume = useBehavior(vm.setSoundEffectVolume$);
   const toggleBlur = useBehavior(vm.toggleBlur$);
   const videoBlurEnabled = useBehavior(vm.videoBlurEnabled$);
   const buttonSize = useBehavior(vm.buttonSize$);
@@ -180,16 +185,18 @@ export const CallFooter: FC<FooterProps> = ({
     );
   }
 
-  // The audio menu exists wherever an output can be selected. It names the
-  // output in use even when there is no microphone to list.
+  // The audio menu exists wherever its actions do. It names the output in use
+  // even when there is no microphone to list.
   const audioControls =
-    selectAudioOutputOption === undefined
+    selectAudioOutputOption === undefined || setSoundEffectVolume === undefined
       ? undefined
       : {
           outputOptions: audioOutputOptions ?? [],
           selectedOutput: selectedAudioOutput,
           onSelectOutput: selectAudioOutputOption,
           micDeviceId: selectedAudio,
+          soundEffectVolume: soundEffectVolume ?? 0,
+          onSoundEffectVolumeCommit: setSoundEffectVolume,
         };
 
   if ((audioOptions?.length ?? 0) > 0 || audioControls !== undefined) {

--- a/src/components/CallFooter.tsx
+++ b/src/components/CallFooter.tsx
@@ -7,6 +7,7 @@ Please see LICENSE in the repository root for full details.
 
 import { type FC, type JSX, type Ref, useMemo } from "react";
 import classNames from "classnames";
+import { useTranslation } from "react-i18next";
 
 import LogoMark from "../icons/LogoMark.svg?react";
 import LogoType from "../icons/LogoType.svg?react";
@@ -25,6 +26,7 @@ import styles from "./CallFooter.module.css";
 import {
   MediaMuteAndSwitchButton,
   type MenuOptions,
+  type OutputMenuOptions,
 } from "./MediaMuteAndSwitchButton";
 import { type Behavior } from "../state/Behavior";
 import { type ViewModel } from "../state/ViewModel";
@@ -105,6 +107,15 @@ export interface FooterState {
   selectedVideo: string | undefined;
   selectAudioButtonOption: ((deviceId: string) => void) | undefined;
   selectVideoButtonOption: ((option: string) => void) | undefined;
+
+  /**
+   * The audio outputs offered by the audio menu. Empty where the browser does
+   * not allow choosing one; the menu then names the default output.
+   */
+  audioOutputOptions: OutputMenuOptions[];
+  selectedAudioOutput: string | undefined;
+  /** Also controls whether the microphone chevron opens the audio menu */
+  selectAudioOutputOption: ((deviceId: string) => void) | undefined;
 }
 
 export interface FooterProps {
@@ -119,6 +130,7 @@ export const CallFooter: FC<FooterProps> = ({
   children,
   vm,
 }) => {
+  const { t } = useTranslation();
   const asOverlay = useBehavior(vm.asOverlay$);
   const showFooter = useBehavior(vm.showFooter$);
   const hideControls = useBehavior(vm.hideControls$);
@@ -144,6 +156,9 @@ export const CallFooter: FC<FooterProps> = ({
   const selectedAudio = useBehavior(vm.selectedAudio$);
   const selectAudioButtonOption = useBehavior(vm.selectAudioButtonOption$);
   const selectVideoButtonOption = useBehavior(vm.selectVideoButtonOption$);
+  const audioOutputOptions = useBehavior(vm.audioOutputOptions$);
+  const selectedAudioOutput = useBehavior(vm.selectedAudioOutput$);
+  const selectAudioOutputOption = useBehavior(vm.selectAudioOutputOption$);
   const toggleBlur = useBehavior(vm.toggleBlur$);
   const videoBlurEnabled = useBehavior(vm.videoBlurEnabled$);
   const buttonSize = useBehavior(vm.buttonSize$);
@@ -165,10 +180,21 @@ export const CallFooter: FC<FooterProps> = ({
     );
   }
 
-  if ((audioOptions?.length ?? 0) > 0) {
+  // The audio menu exists wherever an output can be selected. It names the
+  // output in use even when there is no microphone to list.
+  const audioControls =
+    selectAudioOutputOption === undefined
+      ? undefined
+      : {
+          outputOptions: audioOutputOptions ?? [],
+          selectedOutput: selectedAudioOutput,
+          onSelectOutput: selectAudioOutputOption,
+        };
+
+  if ((audioOptions?.length ?? 0) > 0 || audioControls !== undefined) {
     buttons.push(
       <MediaMuteAndSwitchButton
-        title={"Mic Source"}
+        title={audioControls ? t("audio_menu.title") : "Mic Source"}
         key="audio"
         iconsAndLabels="audio"
         enabled={audioEnabled ?? false}
@@ -178,6 +204,7 @@ export const CallFooter: FC<FooterProps> = ({
         options={audioOptions}
         selectedOption={selectedAudio}
         onSelect={selectAudioButtonOption}
+        audioControls={audioControls}
       />,
     );
   } else {

--- a/src/components/CallFooter.tsx
+++ b/src/components/CallFooter.tsx
@@ -189,6 +189,7 @@ export const CallFooter: FC<FooterProps> = ({
           outputOptions: audioOutputOptions ?? [],
           selectedOutput: selectedAudioOutput,
           onSelectOutput: selectAudioOutputOption,
+          micDeviceId: selectedAudio,
         };
 
   if ((audioOptions?.length ?? 0) > 0 || audioControls !== undefined) {

--- a/src/components/CallFooterViewModel.test.ts
+++ b/src/components/CallFooterViewModel.test.ts
@@ -17,7 +17,10 @@ import type {
   AudioOutputDeviceLabel,
   DeviceLabel,
 } from "../state/MediaDevices";
-import { createCallFooterViewModel } from "./CallFooterViewModel";
+import {
+  createCallFooterViewModel,
+  createLobbyFooterViewModel,
+} from "./CallFooterViewModel";
 import { HeaderStyle } from "../UrlParams";
 import { type FooterSnapshot } from "./CallFooter";
 import { type ViewModel } from "../state/ViewModel";
@@ -146,6 +149,23 @@ describe("createCallFooterViewModel", () => {
       expect(vm.audioOutputOptions$.value).toEqual([]);
       expect(vm.selectAudioOutputOption$.value).toBeUndefined();
       expect(vm.setSoundEffectVolume$.value).toBeUndefined();
+    });
+
+    it("audio menu is present pre-join on every platform", () => {
+      for (const platform of ["desktop", "android", "ios"]) {
+        platformMock.mockReturnValue(platform);
+        const vm = createLobbyFooterViewModel(
+          testScope(),
+          mockMuteStates(),
+          twoOutputsMediaDevices,
+          undefined,
+          undefined,
+          false,
+        );
+        expect(vm.audioOutputOptions$.value).toHaveLength(2);
+        expect(vm.selectAudioOutputOption$.value).toBeDefined();
+        expect(vm.setSoundEffectVolume$.value).toBeDefined();
+      }
     });
 
     it("reads and writes the sound-effect volume setting on desktop", () => {

--- a/src/components/CallFooterViewModel.test.ts
+++ b/src/components/CallFooterViewModel.test.ts
@@ -13,9 +13,14 @@ import { constant } from "../state/Behavior";
 import type { CallViewModel } from "../state/CallViewModel/CallViewModel";
 import type { Alignment, Layout } from "../state/layout-types";
 import type { SpotlightTileViewModel } from "../state/TileViewModel";
-import type { DeviceLabel } from "../state/MediaDevices";
+import type {
+  AudioOutputDeviceLabel,
+  DeviceLabel,
+} from "../state/MediaDevices";
 import { createCallFooterViewModel } from "./CallFooterViewModel";
 import { HeaderStyle } from "../UrlParams";
+import { type FooterSnapshot } from "./CallFooter";
+import { type ViewModel } from "../state/ViewModel";
 
 const platformMock = vi.hoisted(() => vi.fn(() => "desktop"));
 vi.mock("../Platform", () => ({
@@ -95,7 +100,62 @@ const twoMicsAndOneCamMediaDevices = mockMediaDevices({
   },
 });
 
+const selectOutput = vi.fn();
+const twoOutputsMediaDevices = mockMediaDevices({
+  audioOutput: {
+    available$: constant(
+      new Map<string, AudioOutputDeviceLabel>([
+        ["", { type: "default", name: "Built-in Speakers" }],
+        ["out2", { type: "name", name: "Headset" }],
+      ]),
+    ),
+    selected$: constant({ id: "out2", virtualEarpiece: false }),
+    select: selectOutput,
+  },
+});
+
 describe("createCallFooterViewModel", () => {
+  describe("audio output", () => {
+    function createVm(
+      platform: string,
+      layout: Layout,
+    ): ViewModel<FooterSnapshot> {
+      platformMock.mockReturnValue(platform);
+      return createCallFooterViewModel(
+        testScope(),
+        buildMinimalCallViewModel(layout),
+        mockMuteStates(),
+        twoOutputsMediaDevices,
+        /* reactionIdentifier */ undefined,
+        { showControls: true, header: HeaderStyle.Standard },
+      );
+    }
+
+    it("offers no audio menu when the platform is iOS", () => {
+      const vm = createVm("ios", gridLayout);
+      expect(vm.audioOutputOptions$.value).toEqual([]);
+      expect(vm.selectAudioOutputOption$.value).toBeUndefined();
+    });
+
+    it("offers no audio menu when the layout is pip", () => {
+      const vm = createVm("desktop", pipLayout);
+      expect(vm.audioOutputOptions$.value).toEqual([]);
+      expect(vm.selectAudioOutputOption$.value).toBeUndefined();
+    });
+
+    it("lists the outputs and the selection on desktop", () => {
+      const vm = createVm("desktop", gridLayout);
+      expect(vm.audioOutputOptions$.value).toEqual([
+        { id: "", label: { type: "default", name: "Built-in Speakers" } },
+        { id: "out2", label: { type: "name", name: "Headset" } },
+      ]);
+      expect(vm.selectedAudioOutput$.value).toBe("out2");
+
+      vm.selectAudioOutputOption$.value?.("");
+      expect(selectOutput).toHaveBeenCalledWith("");
+    });
+  });
+
   describe("audioOptions and videoOptions", () => {
     function checkEmptyFor(platform: string, layout: Layout): void {
       platformMock.mockReturnValue(platform);

--- a/src/components/CallFooterViewModel.test.ts
+++ b/src/components/CallFooterViewModel.test.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BehaviorSubject } from "rxjs";
 
 import { testScope, mockMuteStates, mockMediaDevices } from "../utils/test";
@@ -21,6 +21,7 @@ import { createCallFooterViewModel } from "./CallFooterViewModel";
 import { HeaderStyle } from "../UrlParams";
 import { type FooterSnapshot } from "./CallFooter";
 import { type ViewModel } from "../state/ViewModel";
+import { soundEffectVolume } from "../settings/settings";
 
 const platformMock = vi.hoisted(() => vi.fn(() => "desktop"));
 vi.mock("../Platform", () => ({
@@ -115,7 +116,9 @@ const twoOutputsMediaDevices = mockMediaDevices({
 });
 
 describe("createCallFooterViewModel", () => {
-  describe("audio output", () => {
+  describe("audio menu", () => {
+    afterEach(() => soundEffectVolume.setValue(0.5));
+
     function createVm(
       platform: string,
       layout: Layout,
@@ -135,12 +138,23 @@ describe("createCallFooterViewModel", () => {
       const vm = createVm("ios", gridLayout);
       expect(vm.audioOutputOptions$.value).toEqual([]);
       expect(vm.selectAudioOutputOption$.value).toBeUndefined();
+      expect(vm.setSoundEffectVolume$.value).toBeUndefined();
     });
 
     it("offers no audio menu when the layout is pip", () => {
       const vm = createVm("desktop", pipLayout);
       expect(vm.audioOutputOptions$.value).toEqual([]);
       expect(vm.selectAudioOutputOption$.value).toBeUndefined();
+      expect(vm.setSoundEffectVolume$.value).toBeUndefined();
+    });
+
+    it("reads and writes the sound-effect volume setting on desktop", () => {
+      const vm = createVm("desktop", gridLayout);
+      expect(vm.soundEffectVolume$.value).toBe(0.5);
+
+      vm.setSoundEffectVolume$.value?.(0.2);
+      expect(soundEffectVolume.value$.value).toBe(0.2);
+      expect(vm.soundEffectVolume$.value).toBe(0.2);
     });
 
     it("lists the outputs and the selection on desktop", () => {

--- a/src/components/CallFooterViewModel.tsx
+++ b/src/components/CallFooterViewModel.tsx
@@ -9,7 +9,10 @@ import { combineLatest, map, switchMap } from "rxjs";
 import { supportsBackgroundProcessors } from "@livekit/track-processors";
 
 import { type CallViewModel } from "../state/CallViewModel/CallViewModel";
-import { type MenuOptions } from "./MediaMuteAndSwitchButton";
+import {
+  type MenuOptions,
+  type OutputMenuOptions,
+} from "./MediaMuteAndSwitchButton";
 import { type MediaDevices } from "../state/MediaDevices";
 import {
   backgroundBlur as backgroundBlurSettings,
@@ -54,8 +57,10 @@ function buildMuteBehaviors(
 }
 
 /**
- * Shared helper: maps MediaDevices into the audio/video device-list behaviors
- * needed by FooterSnapshot (options, selection, callbacks, blur toggle).
+ * Shared helper: maps MediaDevices into every device behavior FooterSnapshot
+ * needs, for the switcher menus and the audio menu alike. The output list is
+ * empty wherever the browser cannot switch output; the menu then names the
+ * default rather than hiding the group.
  */
 function buildDeviceBehaviors(
   scope: ObservableScope,
@@ -72,6 +77,9 @@ function buildDeviceBehaviors(
   | "selectVideoButtonOption$"
   | "toggleBlur$"
   | "videoBlurEnabled$"
+  | "audioOutputOptions$"
+  | "selectedAudioOutput$"
+  | "selectAudioOutputOption$"
 > {
   return {
     audioOptions$: scope.behavior(
@@ -126,6 +134,34 @@ function buildDeviceBehaviors(
       ),
     ),
     videoBlurEnabled$: backgroundBlurSettings.value$,
+    audioOutputOptions$: scope.behavior(
+      disableSwitcher$.pipe(
+        switchMap((disable) =>
+          disable
+            ? constant([] as OutputMenuOptions[])
+            : mediaDevices.audioOutput.available$.pipe(
+                map((available) =>
+                  [...available.entries()].map(([id, label]) => ({
+                    id,
+                    label,
+                  })),
+                ),
+              ),
+        ),
+      ),
+    ),
+    selectedAudioOutput$: scope.behavior(
+      mediaDevices.audioOutput.selected$.pipe(map((s) => s?.id)),
+    ),
+    selectAudioOutputOption$: scope.behavior(
+      disableSwitcher$.pipe(
+        map((disable) =>
+          disable
+            ? undefined
+            : (id: string): void => mediaDevices.audioOutput.select(id),
+        ),
+      ),
+    ),
   };
 }
 
@@ -270,6 +306,8 @@ export function createLobbyFooterViewModel(
       selectVideoButtonOption: undefined,
     }),
     ...buildMuteBehaviors(scope, muteStates),
+    // Nothing is gated before joining: the chevron already exists on every
+    // platform there, and a device check matters most before a call starts.
     ...buildDeviceBehaviors(scope, mediaDevices, constant(false)),
   };
 }

--- a/src/components/CallFooterViewModel.tsx
+++ b/src/components/CallFooterViewModel.tsx
@@ -17,6 +17,7 @@ import { type MediaDevices } from "../state/MediaDevices";
 import {
   backgroundBlur as backgroundBlurSettings,
   debugTileLayout as debugTileLayoutSetting,
+  soundEffectVolume as soundEffectVolumeSetting,
 } from "../settings/settings";
 import { type Behavior, constant } from "../state/Behavior";
 import type { ObservableScope } from "../state/ObservableScope";
@@ -57,10 +58,10 @@ function buildMuteBehaviors(
 }
 
 /**
- * Shared helper: maps MediaDevices into every device behavior FooterSnapshot
- * needs, for the switcher menus and the audio menu alike. The output list is
- * empty wherever the browser cannot switch output; the menu then names the
- * default rather than hiding the group.
+ * Shared helper: maps MediaDevices and the sound-effect setting into every
+ * device behavior FooterSnapshot needs, for the switcher menus and the audio
+ * menu alike. The output list is empty wherever the browser cannot switch
+ * output; the menu then names the default rather than hiding the group.
  */
 function buildDeviceBehaviors(
   scope: ObservableScope,
@@ -80,6 +81,8 @@ function buildDeviceBehaviors(
   | "audioOutputOptions$"
   | "selectedAudioOutput$"
   | "selectAudioOutputOption$"
+  | "soundEffectVolume$"
+  | "setSoundEffectVolume$"
 > {
   return {
     audioOptions$: scope.behavior(
@@ -159,6 +162,17 @@ function buildDeviceBehaviors(
           disable
             ? undefined
             : (id: string): void => mediaDevices.audioOutput.select(id),
+        ),
+      ),
+    ),
+    soundEffectVolume$: soundEffectVolumeSetting.value$,
+    setSoundEffectVolume$: scope.behavior(
+      disableSwitcher$.pipe(
+        map((disable) =>
+          disable
+            ? undefined
+            : (volume: number): void =>
+                soundEffectVolumeSetting.setValue(volume),
         ),
       ),
     ),

--- a/src/components/MediaMuteAndSwitchButton.module.css
+++ b/src/components/MediaMuteAndSwitchButton.module.css
@@ -47,3 +47,33 @@ Please see LICENSE in the repository root for full details.
   color: var(--cpd-color-text-primary);
   font: var(--cpd-font-body-md-regular);
 }
+
+.micSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-1x);
+}
+
+.stickyMeter {
+  position: sticky;
+  inset-block-end: 0;
+  /* Opaque, so the device rows scrolling underneath do not show through. */
+  background: var(--cpd-color-bg-canvas-default);
+  padding-block-start: var(--cpd-space-1x);
+  /* The menu draws its border as an outline inset by one border width. This
+     row is positioned and opaque, so without the matching inset it paints over
+     that border at the left and right edges. */
+  margin-inline: var(--cpd-border-width-1);
+}
+
+/* Radix moves DOM focus onto whichever item the pointer is over, so the
+   browser's own focus ring shows up during mouse use. Keyboard navigation
+   gets the border; the pointer gets the hover background and nothing else. */
+.menu [role^="menuitem"]:focus {
+  outline: none;
+}
+
+.menu [role^="menuitem"]:focus-visible {
+  outline: var(--cpd-border-width-2) solid var(--cpd-color-border-focused);
+  outline-offset: calc(-1 * var(--cpd-border-width-2));
+}

--- a/src/components/MediaMuteAndSwitchButton.module.css
+++ b/src/components/MediaMuteAndSwitchButton.module.css
@@ -113,14 +113,14 @@ Please see LICENSE in the repository root for full details.
   flex: 1;
 }
 
-/* Radix moves DOM focus onto whichever item the pointer is over, so the
+/* The menu moves focus onto whichever item the pointer is over, so the
    browser's own focus ring shows up during mouse use. Keyboard navigation
    gets the border; the pointer gets the hover background and nothing else. */
 .menu [role^="menuitem"]:focus {
   outline: none;
 }
 
-.menu [role^="menuitem"]:focus-visible {
+.keyboardNav [role^="menuitem"]:focus {
   outline: var(--cpd-border-width-2) solid var(--cpd-color-border-focused);
   outline-offset: calc(-1 * var(--cpd-border-width-2));
 }

--- a/src/components/MediaMuteAndSwitchButton.module.css
+++ b/src/components/MediaMuteAndSwitchButton.module.css
@@ -35,3 +35,15 @@ Please see LICENSE in the repository root for full details.
     transform: rotate(360deg);
   }
 }
+
+/* The speaker group's one row where there is no choice to make: it names the
+   output in use wherever audio cannot be redirected. Laid out like a menu item
+   so it lines up with the rows around it. */
+.readOnlyRow {
+  display: flex;
+  align-items: center;
+  gap: var(--cpd-space-4x);
+  padding: var(--cpd-space-3x) var(--cpd-space-4x);
+  color: var(--cpd-color-text-primary);
+  font: var(--cpd-font-body-md-regular);
+}

--- a/src/components/MediaMuteAndSwitchButton.module.css
+++ b/src/components/MediaMuteAndSwitchButton.module.css
@@ -66,6 +66,53 @@ Please see LICENSE in the repository root for full details.
   margin-inline: var(--cpd-border-width-1);
 }
 
+/* Bound the whole menu to the space Radix reports for it, so that the scroll
+   area below can shrink while the heading and the slider, its flex siblings,
+   keep their size and stay on screen. The bound has to cover the menu's own
+   padding, or the padding lands outside it and carries the heading off the
+   top of the viewport; the 2x keeps a small gap to the viewport edge. */
+.menu {
+  box-sizing: border-box;
+  max-block-size: calc(
+    var(--radix-dropdown-menu-content-available-height) - var(--cpd-space-2x)
+  );
+}
+
+.scrollArea {
+  flex: 1 1 auto;
+  min-block-size: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  /* The menu lays its children out as a flex column; the scroll area has to
+     repeat that for the children it now owns. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-1x);
+}
+
+.volumeRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-2x);
+  padding: var(--cpd-space-3x) var(--cpd-space-4x);
+}
+
+.volumeLabel {
+  font: var(--cpd-font-body-md-medium);
+  color: var(--cpd-color-text-primary);
+}
+
+.volumeControl {
+  display: flex;
+  align-items: center;
+  gap: var(--cpd-space-3x);
+}
+
+.volumeSlider {
+  flex: 1;
+}
+
 /* Radix moves DOM focus onto whichever item the pointer is over, so the
    browser's own focus ring shows up during mouse use. Keyboard navigation
    gets the border; the pointer gets the hover background and nothing else. */

--- a/src/components/MediaMuteAndSwitchButton.test.tsx
+++ b/src/components/MediaMuteAndSwitchButton.test.tsx
@@ -5,8 +5,14 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { describe, expect, test, vi } from "vitest";
-import { act, render, screen, type RenderResult } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  type RenderResult,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type JSX, useState, type ReactNode } from "react";
 import { TooltipProvider } from "@vector-im/compound-web";
@@ -363,6 +369,97 @@ describe("MediaMuteAndSwitchButton", () => {
 });
 
 describe("audio menu", () => {
+  test("level indicator responds while muted", async () => {
+    await openAudioMenu({ enabled: false });
+
+    // Muting must not stop the meter: checking the microphone before unmuting
+    // is the whole point of it.
+    await waitFor(() =>
+      expect(getUserMedia).toHaveBeenCalledWith({
+        audio: { deviceId: { exact: "mic-1" } },
+      }),
+    );
+    expect(screen.getByRole("meter")).toBeInTheDocument();
+  });
+
+  test("audio menu starts capture on open and stops on close", async () => {
+    const user = userEvent.setup();
+    renderAudioMenu();
+    expect(getUserMedia).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+
+    await user.keyboard("[Escape]");
+    await waitFor(() => expect(stop).toHaveBeenCalled());
+  });
+
+  test("level indicator follows a microphone change", async () => {
+    const user = userEvent.setup();
+    function Wrapper(): JSX.Element {
+      const [mic, setMic] = useState("mic-1");
+      return (
+        <MediaMuteAndSwitchButton
+          title="Audio controls"
+          iconsAndLabels="audio"
+          enabled
+          onMuteClick={vi.fn()}
+          options={micOptions}
+          selectedOption={mic}
+          onSelect={setMic}
+          audioControls={audioControls({ micDeviceId: mic })}
+        />
+      );
+    }
+    renderComponent(<Wrapper />);
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    await waitFor(() =>
+      expect(getUserMedia).toHaveBeenLastCalledWith({
+        audio: { deviceId: { exact: "mic-1" } },
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("menuitemradio", { name: "Headset Microphone" }),
+    );
+
+    await waitFor(() =>
+      expect(getUserMedia).toHaveBeenLastCalledWith({
+        audio: { deviceId: { exact: "mic-2" } },
+      }),
+    );
+    expect(stop).toHaveBeenCalled();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("meter")).toBeInTheDocument();
+  });
+
+  test("audio menu hints when microphone permission is denied", async () => {
+    getUserMedia.mockRejectedValue(
+      Object.assign(new Error("no"), { name: "NotAllowedError" }),
+    );
+    await openAudioMenu();
+
+    expect(await screen.findByTestId("mic_level_denied")).toHaveTextContent(
+      /microphone access is blocked/i,
+    );
+    expect(screen.queryByRole("meter")).toBe(null);
+  });
+
+  test("level indicator stays with the microphone list rather than the speakers", async () => {
+    await openAudioMenu();
+
+    // The meter reads the microphone, so it belongs to that group and never
+    // sits among the output controls.
+    const micSection = screen.getByTestId("audio_menu_mic_section");
+    expect(micSection).toContainElement(
+      screen.getByRole("menuitemradio", { name: "Headset Microphone" }),
+    );
+    expect(micSection).toContainElement(screen.getByTestId("mic_level_meter"));
+    expect(micSection).not.toContainElement(
+      screen.getByRole("menuitemradio", { name: "Headset" }),
+    );
+  });
+
   test("audio menu switches microphone and stays open", async () => {
     const onSelect = vi.fn();
     const user = await openAudioMenu({ onSelect });
@@ -460,6 +557,46 @@ describe("audio menu", () => {
       expect(screen.getByRole("menuitemradio", { name })).toBeInTheDocument();
   });
 
+  const stop = vi.fn();
+  const getUserMedia = vi.fn();
+
+  beforeEach(() => {
+    stop.mockClear();
+    getUserMedia.mockReset().mockResolvedValue({
+      getTracks: () => [{ stop }],
+    } as unknown as MediaStream);
+    // Define only mediaDevices: replacing the whole navigator drops the
+    // prototype getters that user-event relies on.
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia },
+      configurable: true,
+    });
+    // jsdom has no AudioContext; the meter only needs a silent analyser.
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        public createAnalyser(): unknown {
+          return {
+            fftSize: 1024,
+            getFloatTimeDomainData: (out: Float32Array): void => {
+              out.fill(0);
+            },
+          };
+        }
+        public createMediaStreamSource(): { connect: () => void } {
+          return { connect: (): void => {} };
+        }
+        public async resume(): Promise<void> {}
+        public async close(): Promise<void> {}
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, "mediaDevices");
+  });
+
   const micOptions = [
     {
       label: { type: "name" as const, name: "Built-in Microphone" },
@@ -482,23 +619,24 @@ describe("audio menu", () => {
       ],
       selectedOutput: "out-1",
       onSelectOutput: vi.fn(),
+      micDeviceId: "mic-1",
       ...over,
     };
   }
 
-  /** Renders the microphone button with the audio menu and opens the menu. */
-  async function openAudioMenu(
-    props: {
-      audioControls?: AudioControls;
-      onSelect?: (id: string) => void;
-    } = {},
-  ): Promise<ReturnType<typeof userEvent.setup>> {
-    const user = userEvent.setup();
+  interface AudioMenuProps {
+    enabled?: boolean;
+    audioControls?: AudioControls;
+    onSelect?: (id: string) => void;
+  }
+
+  /** Renders the microphone button with the audio menu, closed. */
+  function renderAudioMenu(props: AudioMenuProps = {}): void {
     renderComponent(
       <MediaMuteAndSwitchButton
         title="Audio controls"
         iconsAndLabels="audio"
-        enabled
+        enabled={props.enabled ?? true}
         onMuteClick={vi.fn()}
         options={micOptions}
         selectedOption="mic-1"
@@ -506,6 +644,14 @@ describe("audio menu", () => {
         audioControls={props.audioControls ?? audioControls()}
       />,
     );
+  }
+
+  /** Renders the microphone button with the audio menu and opens the menu. */
+  async function openAudioMenu(
+    props: AudioMenuProps = {},
+  ): Promise<ReturnType<typeof userEvent.setup>> {
+    const user = userEvent.setup();
+    renderAudioMenu(props);
     await user.click(screen.getByRole("button", { name: "Microphone" }));
     await screen.findByRole("menu");
     return user;

--- a/src/components/MediaMuteAndSwitchButton.test.tsx
+++ b/src/components/MediaMuteAndSwitchButton.test.tsx
@@ -11,7 +11,10 @@ import userEvent from "@testing-library/user-event";
 import { type JSX, useState, type ReactNode } from "react";
 import { TooltipProvider } from "@vector-im/compound-web";
 
-import { MediaMuteAndSwitchButton } from "./MediaMuteAndSwitchButton";
+import {
+  MediaMuteAndSwitchButton,
+  type AudioControls,
+} from "./MediaMuteAndSwitchButton";
 import { MediaDevicesContext } from "../MediaDevicesContext";
 import { type MediaDevices } from "../state/MediaDevices";
 
@@ -357,4 +360,154 @@ describe("MediaMuteAndSwitchButton", () => {
     });
     expect(mic2Item.querySelectorAll("svg").length).toBe(1);
   });
+});
+
+describe("audio menu", () => {
+  test("audio menu switches microphone and stays open", async () => {
+    const onSelect = vi.fn();
+    const user = await openAudioMenu({ onSelect });
+
+    await user.click(
+      screen.getByRole("menuitemradio", { name: "Headset Microphone" }),
+    );
+
+    expect(onSelect).toHaveBeenCalledWith("mic-2");
+    // Selecting a device must not dismiss the menu: the user needs to see the
+    // choice take effect and may want to change it again.
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  test("audio menu switches audio output and stays open", async () => {
+    const controls = audioControls();
+    const user = await openAudioMenu({ audioControls: controls });
+
+    await user.click(screen.getByRole("menuitemradio", { name: "Headset" }));
+
+    expect(controls.onSelectOutput).toHaveBeenCalledWith("out-2");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  test("audio menu marks the active output below the microphones", async () => {
+    await openAudioMenu();
+
+    expect(
+      screen.getByRole("menuitemradio", { name: "Built-in Speakers" }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("menuitemradio", { name: "Headset" }),
+    ).toHaveAttribute("aria-checked", "false");
+    // One rule between the microphone group and the speaker group.
+    expect(screen.getByRole("menu").querySelectorAll("hr")).toHaveLength(1);
+  });
+
+  test("audio menu does not reselect the active output", async () => {
+    const controls = audioControls();
+    const user = await openAudioMenu({ audioControls: controls });
+
+    await user.click(
+      screen.getByRole("menuitemradio", { name: "Built-in Speakers" }),
+    );
+
+    expect(controls.onSelectOutput).not.toHaveBeenCalled();
+  });
+
+  test("audio menu shows single audio output as non-selectable", async () => {
+    await openAudioMenu({
+      audioControls: audioControls({
+        outputOptions: [
+          { label: { type: "name", name: "Built-in Speakers" }, id: "out-1" },
+        ],
+      }),
+    });
+
+    expect(screen.getByTestId("speaker_readonly")).toHaveTextContent(
+      "Built-in Speakers",
+    );
+    // The one output must not present itself as a choice.
+    expect(
+      screen.queryByRole("menuitemradio", { name: "Built-in Speakers" }),
+    ).toBe(null);
+  });
+
+  test("audio menu names the default output where none can be chosen", async () => {
+    await openAudioMenu({
+      audioControls: audioControls({ outputOptions: [] }),
+    });
+    expect(screen.getByTestId("speaker_readonly")).toHaveTextContent("Default");
+  });
+
+  test("audio menu labels every kind of output", async () => {
+    await openAudioMenu({
+      audioControls: audioControls({
+        outputOptions: [
+          { label: { type: "default", name: "Built-in Speakers" }, id: "" },
+          { label: { type: "default", name: null }, id: "default" },
+          { label: { type: "number", number: 2 }, id: "out-2" },
+          { label: { type: "speaker" }, id: "speaker" },
+          { label: { type: "earpiece" }, id: "earpiece" },
+        ],
+        selectedOutput: "",
+      }),
+    });
+
+    for (const name of [
+      "Default (Built-in Speakers)",
+      "Default",
+      "Speaker 2",
+      "Loudspeaker",
+      "Handset",
+    ])
+      expect(screen.getByRole("menuitemradio", { name })).toBeInTheDocument();
+  });
+
+  const micOptions = [
+    {
+      label: { type: "name" as const, name: "Built-in Microphone" },
+      id: "mic-1",
+    },
+    {
+      label: { type: "name" as const, name: "Headset Microphone" },
+      id: "mic-2",
+    },
+  ];
+
+  function audioControls(over: Partial<AudioControls> = {}): AudioControls {
+    return {
+      outputOptions: [
+        {
+          label: { type: "name" as const, name: "Built-in Speakers" },
+          id: "out-1",
+        },
+        { label: { type: "name" as const, name: "Headset" }, id: "out-2" },
+      ],
+      selectedOutput: "out-1",
+      onSelectOutput: vi.fn(),
+      ...over,
+    };
+  }
+
+  /** Renders the microphone button with the audio menu and opens the menu. */
+  async function openAudioMenu(
+    props: {
+      audioControls?: AudioControls;
+      onSelect?: (id: string) => void;
+    } = {},
+  ): Promise<ReturnType<typeof userEvent.setup>> {
+    const user = userEvent.setup();
+    renderComponent(
+      <MediaMuteAndSwitchButton
+        title="Audio controls"
+        iconsAndLabels="audio"
+        enabled
+        onMuteClick={vi.fn()}
+        options={micOptions}
+        selectedOption="mic-1"
+        onSelect={props.onSelect ?? vi.fn()}
+        audioControls={props.audioControls ?? audioControls()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Microphone" }));
+    await screen.findByRole("menu");
+    return user;
+  }
 });

--- a/src/components/MediaMuteAndSwitchButton.test.tsx
+++ b/src/components/MediaMuteAndSwitchButton.test.tsx
@@ -484,7 +484,7 @@ describe("audio menu", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
   });
 
-  test("audio menu marks the active output below the microphones", async () => {
+  test("audio menu marks the active output", async () => {
     await openAudioMenu();
 
     expect(
@@ -493,8 +493,88 @@ describe("audio menu", () => {
     expect(
       screen.getByRole("menuitemradio", { name: "Headset" }),
     ).toHaveAttribute("aria-checked", "false");
-    // One rule between the microphone group and the speaker group.
-    expect(screen.getByRole("menu").querySelectorAll("hr")).toHaveLength(1);
+  });
+
+  test("audio menu separates microphone speaker and sound effects groups", async () => {
+    await openAudioMenu();
+
+    // One rule after the microphone group, one after the speaker group.
+    expect(screen.getByRole("menu").querySelectorAll("hr")).toHaveLength(2);
+    expect(screen.getByTestId("mic_level_meter")).toBeInTheDocument();
+    expect(screen.getByTestId("sound_effect_volume")).toBeInTheDocument();
+  });
+
+  test("audio menu keeps its title and volume slider out of the scrolling area", async () => {
+    await openAudioMenu();
+
+    // Machines with many inputs and outputs produce a device list taller than
+    // the menu can be. Only that list scrolls; the heading above it and the
+    // sound-effect slider below it stay put.
+    const scroll = screen.getByTestId("audio_menu_scroll");
+    expect(scroll).toContainElement(
+      screen.getByRole("menuitemradio", { name: "Headset Microphone" }),
+    );
+    expect(scroll).toContainElement(
+      screen.getByRole("menuitemradio", { name: "Headset" }),
+    );
+    expect(scroll).not.toContainElement(
+      screen.getByTestId("sound_effect_volume"),
+    );
+    expect(scroll).not.toContainElement(
+      screen.getByRole("heading", { name: "Audio controls" }),
+    );
+  });
+
+  test("audio menu is fully operable from the keyboard", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const controls = audioControls();
+    renderAudioMenu({ onSelect, audioControls: controls });
+
+    // Open from the chevron; the first device row takes focus.
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Microphone" })).toHaveFocus();
+    await user.keyboard("[Enter]");
+    await screen.findByRole("menu");
+    expect(
+      screen.getByRole("menuitemradio", { name: "Built-in Microphone" }),
+    ).toHaveFocus();
+
+    // Arrow keys walk the microphone rows; Enter selects and keeps the menu.
+    await user.keyboard("[ArrowDown]");
+    const headsetMic = screen.getByRole("menuitemradio", {
+      name: /Headset Microphone/,
+    });
+    expect(headsetMic).toHaveFocus();
+    await user.keyboard("[Enter]");
+    expect(onSelect).toHaveBeenCalledWith("mic-2");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    // Tab reaches the meter below the microphones, then the slider; arrow
+    // keys adjust the slider without moving the menu's focus.
+    await user.tab();
+    expect(screen.getByRole("meter")).toHaveFocus();
+    await user.tab();
+    const slider = screen.getByRole("slider", { name: /Sound effect volume/ });
+    expect(slider).toHaveFocus();
+    await user.keyboard("[ArrowRight]");
+    expect(controls.onSoundEffectVolumeCommit).toHaveBeenCalledWith(0.51);
+    expect(slider).toHaveFocus();
+
+    // Shift+Tab walks back to the meter and the current row; from there the
+    // arrow keys carry on into the speaker rows.
+    await user.tab({ shift: true });
+    expect(screen.getByRole("meter")).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(headsetMic).toHaveFocus();
+    await user.keyboard("[ArrowDown][ArrowDown]");
+    expect(
+      screen.getByRole("menuitemradio", { name: "Headset" }),
+    ).toHaveFocus();
+    await user.keyboard("[Enter]");
+    expect(controls.onSelectOutput).toHaveBeenCalledWith("out-2");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
   });
 
   test("audio menu does not reselect the active output", async () => {
@@ -620,6 +700,8 @@ describe("audio menu", () => {
       selectedOutput: "out-1",
       onSelectOutput: vi.fn(),
       micDeviceId: "mic-1",
+      soundEffectVolume: 0.5,
+      onSoundEffectVolumeCommit: vi.fn(),
       ...over,
     };
   }

--- a/src/components/MediaMuteAndSwitchButton.test.tsx
+++ b/src/components/MediaMuteAndSwitchButton.test.tsx
@@ -369,6 +369,17 @@ describe("MediaMuteAndSwitchButton", () => {
 });
 
 describe("audio menu", () => {
+  test("level indicator is on screen as soon as the menu opens", async () => {
+    // A microphone takes a moment to open. The meter waits at rest rather
+    // than appearing late and pushing the rest of the menu down.
+    getUserMedia.mockReturnValue(new Promise<MediaStream>(() => {}));
+    await openAudioMenu();
+
+    const meter = screen.getByRole("meter");
+    expect(meter).toHaveAttribute("aria-valuenow", "0");
+    expect(screen.queryByTestId("mic_absent")).toBe(null);
+  });
+
   test("level indicator responds while muted", async () => {
     await openAudioMenu({ enabled: false });
 
@@ -482,6 +493,25 @@ describe("audio menu", () => {
 
     expect(controls.onSelectOutput).toHaveBeenCalledWith("out-2");
     expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  test("audio menu says when there is no microphone", async () => {
+    await openAudioMenu({
+      micOptions: [],
+      audioControls: audioControls({ micDeviceId: undefined }),
+    });
+
+    // A meter resting at zero would read as a microphone that hears nothing,
+    // so the group names the absence instead.
+    expect(screen.getByTestId("mic_absent")).toHaveTextContent(
+      /no microphone found/i,
+    );
+    expect(screen.queryByRole("meter")).toBe(null);
+    // The rest of the menu is unaffected.
+    expect(
+      screen.getByRole("menuitemradio", { name: "Built-in Speakers" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("sound_effect_volume")).toBeInTheDocument();
   });
 
   test("audio menu marks the active output", async () => {
@@ -710,6 +740,7 @@ describe("audio menu", () => {
     enabled?: boolean;
     audioControls?: AudioControls;
     onSelect?: (id: string) => void;
+    micOptions?: typeof micOptions;
   }
 
   /** Renders the microphone button with the audio menu, closed. */
@@ -720,7 +751,7 @@ describe("audio menu", () => {
         iconsAndLabels="audio"
         enabled={props.enabled ?? true}
         onMuteClick={vi.fn()}
-        options={micOptions}
+        options={props.micOptions ?? micOptions}
         selectedOption="mic-1"
         onSelect={props.onSelect ?? vi.fn()}
         audioControls={props.audioControls ?? audioControls()}

--- a/src/components/MediaMuteAndSwitchButton.test.tsx
+++ b/src/components/MediaMuteAndSwitchButton.test.tsx
@@ -555,6 +555,26 @@ describe("audio menu", () => {
     );
   });
 
+  test("the focus border marks keyboard use and never the pointer", async () => {
+    const user = await openAudioMenu();
+    const menu = screen.getByRole("menu");
+    const rows = screen.getAllByRole("menuitemradio");
+
+    // Opened and driven by pointer: the hover background alone.
+    await user.hover(rows[1]);
+    expect(menu.className).not.toMatch(/keyboardNav/);
+
+    // One arrow key, and the border marks where the keyboard is.
+    await user.keyboard("[ArrowDown]");
+    expect(menu.className).toMatch(/keyboardNav/);
+
+    // Back to the pointer, and the border goes with it: the browser calls
+    // every focus after a key press keyboard-driven, so this cannot be left
+    // to :focus-visible.
+    await user.hover(rows[0]);
+    expect(menu.className).not.toMatch(/keyboardNav/);
+  });
+
   test("audio menu is fully operable from the keyboard", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -5,7 +5,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { type ComponentType, useState, type FC, useEffect } from "react";
+import {
+  type ComponentType,
+  useState,
+  type FC,
+  useEffect,
+  type JSX,
+} from "react";
 import {
   Button,
   Menu,
@@ -19,18 +25,41 @@ import {
   MicOnIcon,
   SpinnerIcon,
   VideoCallIcon,
+  VolumeOnIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";
 
 import styles from "./MediaMuteAndSwitchButton.module.css";
 import { MicButton, VideoButton } from "../button";
-import { type DeviceLabel } from "../state/MediaDevices";
+import {
+  type AudioOutputDeviceLabel,
+  type DeviceLabel,
+} from "../state/MediaDevices";
 import { useMediaDevices } from "../MediaDevicesContext";
 
 export interface MenuOptions {
   label: DeviceLabel;
   id: string;
+}
+
+export interface OutputMenuOptions {
+  label: AudioOutputDeviceLabel;
+  id: string;
+}
+
+/**
+ * The controls that turn the microphone chevron menu into the audio menu: a
+ * speaker group below the microphone list. Absent for the camera menu.
+ */
+export interface AudioControls {
+  /**
+   * The audio outputs to choose from. Empty where the browser does not allow
+   * choosing one; the menu then names the default output instead.
+   */
+  outputOptions: OutputMenuOptions[];
+  selectedOutput: string | undefined;
+  onSelectOutput: (id: string) => void;
 }
 
 export interface MediaMuteAndSwitchButtonProps {
@@ -49,6 +78,8 @@ export interface MediaMuteAndSwitchButtonProps {
   selectedOption?: string;
   videoBlurToggleClick?: () => void;
   videoBlurEnabled?: boolean;
+  /** When present, the menu renders the speaker group below the microphone list. */
+  audioControls?: AudioControls;
   /**
    * For any toggle and option this method will be called.
    * So toggles need to be implemented by listening here and setting the right toggle item to `enabled`
@@ -69,6 +100,7 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
   videoBlurEnabled,
   videoBlurToggleClick,
   onSelect,
+  audioControls,
 }) => {
   const [plannedSelection, setPlannedSelection] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -223,6 +255,16 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
             </MenuItem>
           );
         })}
+        {audioControls && (
+          <>
+            <hr />
+            <SpeakerSection
+              options={audioControls.outputOptions}
+              selected={audioControls.selectedOutput}
+              onSelect={audioControls.onSelectOutput}
+            />
+          </>
+        )}
         {(toggles?.length ?? 0) > 0 && <hr />}
         {toggles?.map((toggle) => (
           <ToggleMenuItem
@@ -239,3 +281,82 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
     </div>
   );
 };
+
+interface SpeakerSectionProps {
+  options: OutputMenuOptions[];
+  selected: string | undefined;
+  onSelect: (id: string) => void;
+}
+
+/**
+ * The speaker group of the audio menu.
+ *
+ * With more than one output to choose from this is a radio group. With one or
+ * none it still names the output in use, as a plain row: knowing where audio
+ * goes is useful even where it cannot be redirected, as in browsers that do
+ * not support choosing an output at all.
+ */
+function SpeakerSection({
+  options,
+  selected,
+  onSelect,
+}: SpeakerSectionProps): JSX.Element {
+  const { t } = useTranslation();
+  const labelText = (label: AudioOutputDeviceLabel): string => {
+    switch (label.type) {
+      case "name":
+        return label.name;
+      case "number":
+        return t("settings.devices.speaker_numbered", { n: label.number });
+      case "speaker":
+        return t("settings.devices.loudspeaker");
+      case "earpiece":
+        return t("settings.devices.handset");
+      case "default":
+        return label.name === null
+          ? t("settings.devices.default")
+          : `${t("settings.devices.default")} (${label.name})`;
+    }
+  };
+  const icon = (
+    <VolumeOnIcon
+      width={24}
+      height={24}
+      className={styles.itemIcon}
+      aria-hidden
+    />
+  );
+
+  if (options.length <= 1) {
+    const only = options[0];
+    return (
+      <div className={styles.readOnlyRow} data-testid="speaker_readonly">
+        {icon}
+        <span>
+          {only ? labelText(only.label) : t("settings.devices.default")}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {options.map(({ id, label }) => (
+        <MenuItem
+          hideChevron
+          key={id}
+          label={labelText(label)}
+          Icon={icon}
+          onSelect={(e) => {
+            e.preventDefault();
+            if (id !== selected) onSelect(id);
+          }}
+          role="menuitemradio"
+          aria-checked={selected === id}
+        >
+          {selected === id && <CheckIcon width={24} height={24} aria-hidden />}
+        </MenuItem>
+      ))}
+    </>
+  );
+}

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -297,8 +297,8 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
                   screen for as long as any microphone is. */}
               <div className={styles.stickyMeter}>
                 {/* The capture is bound to the menu being open, so the
-                    microphone is only ever held while the user is looking
-                    at the level. */}
+                    microphone is only ever held while the user is looking at
+                    the level. */}
                 <MicrophoneLevel
                   deviceId={audioControls.micDeviceId}
                   active={menuOpen}

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -374,7 +374,7 @@ function SpeakerSection({
       case "default":
         return label.name === null
           ? t("settings.devices.default")
-          : `${t("settings.devices.default")} (${label.name})`;
+          : t("settings.devices.default_named_plain", { name: label.name });
     }
   };
   const icon = (

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -38,8 +38,7 @@ import {
   type DeviceLabel,
 } from "../state/MediaDevices";
 import { useMediaDevices } from "../MediaDevicesContext";
-import { AudioLevelMeter } from "./AudioLevelMeter";
-import { useMicrophoneLevel } from "./useMicrophoneLevel";
+import { MicrophoneLevel } from "./AudioLevelMeter";
 import { Slider } from "../Slider";
 
 export interface MenuOptions {
@@ -131,13 +130,6 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
   useEffect(() => {
     if (menuOpen) devices.requestDeviceNames(); // No-op after the first call
   }, [menuOpen, devices]);
-
-  // The meter's capture is bound to the menu being open, so the microphone is
-  // only ever held while the user is looking at the level.
-  const micLevel = useMicrophoneLevel(
-    audioControls?.micDeviceId,
-    menuOpen && audioControls !== undefined,
-  );
 
   let button;
   let toggles: { label: string; enabled: boolean; id: string }[] = [];
@@ -304,7 +296,13 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
                   controls; pinned to the foot of the scroll port, it stays on
                   screen for as long as any microphone is. */}
               <div className={styles.stickyMeter}>
-                <AudioLevelMeter state={micLevel} />
+                {/* The capture is bound to the menu being open, so the
+                    microphone is only ever held while the user is looking
+                    at the level. */}
+                <MicrophoneLevel
+                  deviceId={audioControls.micDeviceId}
+                  active={menuOpen}
+                />
               </div>
             </div>
             <hr />

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -11,6 +11,7 @@ import {
   type FC,
   useEffect,
   type JSX,
+  type KeyboardEvent,
 } from "react";
 import {
   Button,
@@ -39,6 +40,7 @@ import {
 import { useMediaDevices } from "../MediaDevicesContext";
 import { AudioLevelMeter } from "./AudioLevelMeter";
 import { useMicrophoneLevel } from "./useMicrophoneLevel";
+import { Slider } from "../Slider";
 
 export interface MenuOptions {
   label: DeviceLabel;
@@ -52,7 +54,8 @@ export interface OutputMenuOptions {
 
 /**
  * The controls that turn the microphone chevron menu into the audio menu: a
- * speaker group below the microphone list. Absent for the camera menu.
+ * speaker group and the sound-effect volume below the microphone list. Absent
+ * for the camera menu.
  */
 export interface AudioControls {
   /**
@@ -64,6 +67,8 @@ export interface AudioControls {
   onSelectOutput: (id: string) => void;
   /** The microphone the level meter follows. */
   micDeviceId: string | undefined;
+  soundEffectVolume: number;
+  onSoundEffectVolumeCommit: (volume: number) => void;
 }
 
 export interface MediaMuteAndSwitchButtonProps {
@@ -92,6 +97,17 @@ export interface MediaMuteAndSwitchButtonProps {
 }
 
 const BLUR_ID = "blur";
+/** The keys a slider reads; inside the menu they must not move focus. */
+const SLIDER_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
 
 export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
   title,
@@ -269,18 +285,34 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
         }
       >
         {audioControls ? (
+          // Only the device lists scroll; the title above and the slider below
+          // stay put. Tab moves between the device rows, the meter and the
+          // slider; see keepTabInsideMenu.
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
           <div
-            className={styles.micSection}
-            data-testid="audio_menu_mic_section"
+            className={styles.scrollArea}
+            data-testid="audio_menu_scroll"
+            onKeyDown={keepTabInsideMenu}
           >
-            {deviceItems}
-            {/* The meter reads the microphone, so it travels with the
-                microphone list rather than sitting among the output controls;
-                pinned to the foot of the list, it stays on screen for as long
-                as any microphone is. */}
-            <div className={styles.stickyMeter}>
-              <AudioLevelMeter state={micLevel} />
+            <div
+              className={styles.micSection}
+              data-testid="audio_menu_mic_section"
+            >
+              {deviceItems}
+              {/* The meter reads the microphone, so it travels with the
+                  microphone list rather than sitting among the output
+                  controls; pinned to the foot of the scroll port, it stays on
+                  screen for as long as any microphone is. */}
+              <div className={styles.stickyMeter}>
+                <AudioLevelMeter state={micLevel} />
+              </div>
             </div>
+            <hr />
+            <SpeakerSection
+              options={audioControls.outputOptions}
+              selected={audioControls.selectedOutput}
+              onSelect={audioControls.onSelectOutput}
+            />
           </div>
         ) : (
           deviceItems
@@ -288,10 +320,9 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
         {audioControls && (
           <>
             <hr />
-            <SpeakerSection
-              options={audioControls.outputOptions}
-              selected={audioControls.selectedOutput}
-              onSelect={audioControls.onSelectOutput}
+            <SoundEffectVolume
+              volume={audioControls.soundEffectVolume}
+              onCommit={audioControls.onSoundEffectVolumeCommit}
             />
           </>
         )}
@@ -389,4 +420,76 @@ function SpeakerSection({
       ))}
     </>
   );
+}
+
+interface SoundEffectVolumeProps {
+  volume: number;
+  onCommit: (volume: number) => void;
+}
+
+/** The sound-effect volume slider: the same stored value as in settings. */
+function SoundEffectVolume({
+  volume,
+  onCommit,
+}: SoundEffectVolumeProps): JSX.Element {
+  const { t } = useTranslation();
+  const label = t("settings.audio_tab.effect_volume_label");
+  // Tracked locally so dragging is smooth; only the committed value is
+  // stored. A change made in settings while the menu is open resets it.
+  const [raw, setRaw] = useState(volume);
+  const [committed, setCommitted] = useState(volume);
+  if (volume !== committed) {
+    setCommitted(volume);
+    setRaw(volume);
+  }
+
+  return (
+    // The menu treats the slider's keys as navigation between its items, which
+    // would otherwise stop the slider from ever receiving them. The handler has
+    // to sit on the wrapper because Slider takes no key handler of its own.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <div
+      className={styles.volumeRow}
+      data-testid="sound_effect_volume"
+      role="group"
+      aria-label={label}
+      onKeyDown={(e) => {
+        if (SLIDER_KEYS.has(e.key)) e.stopPropagation();
+        else keepTabInsideMenu(e);
+      }}
+    >
+      <span className={styles.volumeLabel}>{label}</span>
+      <div className={styles.volumeControl}>
+        <VolumeOnIcon
+          width={24}
+          height={24}
+          className={styles.itemIcon}
+          aria-hidden
+        />
+        <Slider
+          className={styles.volumeSlider}
+          label={label}
+          value={raw}
+          onValueChange={setRaw}
+          onValueCommit={onCommit}
+          min={0}
+          max={1}
+          step={0.01}
+          // Slider names its thumb after the tooltip, so the tooltip has to
+          // carry what the control is, not just its value.
+          tooltipFormatter={(v) => `${label}: ${Math.round(v * 100)}%`}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Lets Tab move focus between the device rows, the level meter and the
+ * sound-effect slider. The menu swallows Tab so that its items are walked
+ * with the arrow keys; kept from it, the browser's own focus order takes over,
+ * and the menu's focus trap keeps that order inside the menu.
+ */
+function keepTabInsideMenu(e: KeyboardEvent<HTMLElement>): void {
+  if (e.key === "Tab") e.stopPropagation();
 }

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -37,6 +37,8 @@ import {
   type DeviceLabel,
 } from "../state/MediaDevices";
 import { useMediaDevices } from "../MediaDevicesContext";
+import { AudioLevelMeter } from "./AudioLevelMeter";
+import { useMicrophoneLevel } from "./useMicrophoneLevel";
 
 export interface MenuOptions {
   label: DeviceLabel;
@@ -60,6 +62,8 @@ export interface AudioControls {
   outputOptions: OutputMenuOptions[];
   selectedOutput: string | undefined;
   onSelectOutput: (id: string) => void;
+  /** The microphone the level meter follows. */
+  micDeviceId: string | undefined;
 }
 
 export interface MediaMuteAndSwitchButtonProps {
@@ -111,6 +115,13 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
   useEffect(() => {
     if (menuOpen) devices.requestDeviceNames(); // No-op after the first call
   }, [menuOpen, devices]);
+
+  // The meter's capture is bound to the menu being open, so the microphone is
+  // only ever held while the user is looking at the level.
+  const micLevel = useMicrophoneLevel(
+    audioControls?.micDeviceId,
+    menuOpen && audioControls !== undefined,
+  );
 
   let button;
   let toggles: { label: string; enabled: boolean; id: string }[] = [];
@@ -174,6 +185,59 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
       break;
   }
 
+  const deviceItems = options?.map(({ label, id }) => {
+    let labelText: string;
+    switch (label.type) {
+      case "name":
+        labelText = label.name;
+        break;
+      case "number":
+        labelText = numberedLabel(label.number);
+        break;
+    }
+    return (
+      <MenuItem
+        hideChevron
+        label={labelText}
+        Icon={
+          IconOptions && (
+            <IconOptions
+              width={24}
+              height={24}
+              className={styles.itemIcon}
+              aria-hidden
+            />
+          )
+        }
+        onSelect={(e) => {
+          e.preventDefault();
+          if (id === selectedOption) return;
+          setPlannedSelection(id);
+          onSelect?.(id);
+        }}
+        key={id}
+        role="menuitemradio"
+        aria-checked={selectedOption === id}
+      >
+        {selectedOption === id && (
+          <CheckIcon
+            width={24}
+            height={24}
+            aria-hidden // A label would be redundant to aria-checked above
+          />
+        )}
+        {selectedOption !== id && plannedSelection === id && (
+          <SpinnerIcon
+            width={24}
+            height={24}
+            className={styles.rotate}
+            aria-label={t("settings.devices.activating")}
+          />
+        )}
+      </MenuItem>
+    );
+  });
+
   return (
     <div
       className={classNames({
@@ -184,6 +248,7 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
       {/* The mute button lives inside */}
       {button}
       <Menu
+        className={styles.menu}
         title={title}
         showTitle={true}
         open={menuOpen}
@@ -203,58 +268,23 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
           />
         }
       >
-        {options?.map(({ label, id }) => {
-          let labelText: string;
-          switch (label.type) {
-            case "name":
-              labelText = label.name;
-              break;
-            case "number":
-              labelText = numberedLabel(label.number);
-              break;
-          }
-          return (
-            <MenuItem
-              hideChevron
-              label={labelText}
-              Icon={
-                IconOptions && (
-                  <IconOptions
-                    width={24}
-                    height={24}
-                    className={styles.itemIcon}
-                    aria-hidden
-                  />
-                )
-              }
-              onSelect={(e) => {
-                e.preventDefault();
-                if (id === selectedOption) return;
-                setPlannedSelection(id);
-                onSelect?.(id);
-              }}
-              key={id}
-              role="menuitemradio"
-              aria-checked={selectedOption === id}
-            >
-              {selectedOption === id && (
-                <CheckIcon
-                  width={24}
-                  height={24}
-                  aria-hidden // A label would be redundant to aria-checked above
-                />
-              )}
-              {selectedOption !== id && plannedSelection === id && (
-                <SpinnerIcon
-                  width={24}
-                  height={24}
-                  className={styles.rotate}
-                  aria-label={t("settings.devices.activating")}
-                />
-              )}
-            </MenuItem>
-          );
-        })}
+        {audioControls ? (
+          <div
+            className={styles.micSection}
+            data-testid="audio_menu_mic_section"
+          >
+            {deviceItems}
+            {/* The meter reads the microphone, so it travels with the
+                microphone list rather than sitting among the output controls;
+                pinned to the foot of the list, it stays on screen for as long
+                as any microphone is. */}
+            <div className={styles.stickyMeter}>
+              <AudioLevelMeter state={micLevel} />
+            </div>
+          </div>
+        ) : (
+          deviceItems
+        )}
         {audioControls && (
           <>
             <hr />

--- a/src/components/MediaMuteAndSwitchButton.tsx
+++ b/src/components/MediaMuteAndSwitchButton.tsx
@@ -123,6 +123,13 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
 }) => {
   const [plannedSelection, setPlannedSelection] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  // Which of the two reached the current item, since `:focus-visible` cannot
+  // tell: the menu focuses whatever the pointer is over.
+  const [keyboardNav, setKeyboardNav] = useState(false);
+  const modality = {
+    onKeyDown: (): void => setKeyboardNav(true),
+    onPointerMove: (): void => setKeyboardNav(false),
+  };
   const isBusy = busy ?? false;
   const { t } = useTranslation();
   const devices = useMediaDevices();
@@ -226,6 +233,7 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
         key={id}
         role="menuitemradio"
         aria-checked={selectedOption === id}
+        {...modality}
       >
         {selectedOption === id && (
           <CheckIcon
@@ -256,7 +264,9 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
       {/* The mute button lives inside */}
       {button}
       <Menu
-        className={styles.menu}
+        className={classNames(styles.menu, {
+          [styles.keyboardNav]: keyboardNav,
+        })}
         title={title}
         showTitle={true}
         open={menuOpen}
@@ -273,6 +283,8 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
             kind={"tertiary"}
             size="lg"
             aria-label={optionsButtonLabel}
+            onKeyDown={() => setKeyboardNav(true)}
+            onPointerDown={() => setKeyboardNav(false)}
           />
         }
       >
@@ -295,7 +307,7 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
                   microphone list rather than sitting among the output
                   controls; pinned to the foot of the scroll port, it stays on
                   screen for as long as any microphone is. */}
-              <div className={styles.stickyMeter}>
+              <div className={styles.stickyMeter} {...modality}>
                 {/* The capture is bound to the menu being open, so the
                     microphone is only ever held while the user is looking at
                     the level. */}
@@ -310,6 +322,7 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
               options={audioControls.outputOptions}
               selected={audioControls.selectedOutput}
               onSelect={audioControls.onSelectOutput}
+              modality={modality}
             />
           </div>
         ) : (
@@ -321,12 +334,14 @@ export const MediaMuteAndSwitchButton: FC<MediaMuteAndSwitchButtonProps> = ({
             <SoundEffectVolume
               volume={audioControls.soundEffectVolume}
               onCommit={audioControls.onSoundEffectVolumeCommit}
+              onPointerMove={modality.onPointerMove}
             />
           </>
         )}
         {(toggles?.length ?? 0) > 0 && <hr />}
         {toggles?.map((toggle) => (
           <ToggleMenuItem
+            {...modality}
             label={toggle.label}
             onSelect={(e) => {
               videoBlurToggleClick?.();
@@ -345,6 +360,11 @@ interface SpeakerSectionProps {
   options: OutputMenuOptions[];
   selected: string | undefined;
   onSelect: (id: string) => void;
+  /** Reports whether a row was reached by pointer or by keyboard. */
+  modality: {
+    onKeyDown: () => void;
+    onPointerMove: () => void;
+  };
 }
 
 /**
@@ -359,6 +379,7 @@ function SpeakerSection({
   options,
   selected,
   onSelect,
+  modality,
 }: SpeakerSectionProps): JSX.Element {
   const { t } = useTranslation();
   const labelText = (label: AudioOutputDeviceLabel): string => {
@@ -412,6 +433,7 @@ function SpeakerSection({
           }}
           role="menuitemradio"
           aria-checked={selected === id}
+          {...modality}
         >
           {selected === id && <CheckIcon width={24} height={24} aria-hidden />}
         </MenuItem>
@@ -423,12 +445,14 @@ function SpeakerSection({
 interface SoundEffectVolumeProps {
   volume: number;
   onCommit: (volume: number) => void;
+  onPointerMove: () => void;
 }
 
 /** The sound-effect volume slider: the same stored value as in settings. */
 function SoundEffectVolume({
   volume,
   onCommit,
+  onPointerMove,
 }: SoundEffectVolumeProps): JSX.Element {
   const { t } = useTranslation();
   const label = t("settings.audio_tab.effect_volume_label");
@@ -451,6 +475,7 @@ function SoundEffectVolume({
       data-testid="sound_effect_volume"
       role="group"
       aria-label={label}
+      onPointerMove={onPointerMove}
       onKeyDown={(e) => {
         if (SLIDER_KEYS.has(e.key)) e.stopPropagation();
         else keepTabInsideMenu(e);

--- a/src/components/useMicrophoneLevel.test.tsx
+++ b/src/components/useMicrophoneLevel.test.tsx
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { useMicrophoneLevel } from "./useMicrophoneLevel";
+
+describe("useMicrophoneLevel", () => {
+  test("level indicator follows the microphone signal level", async () => {
+    const { stream } = fakeStream();
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    await waitFor(() => expect(result.current.type).toBe("active"));
+    expect(result.current).toEqual({ type: "active", level: 0 });
+
+    // Speech arrives.
+    amplitude = 0.2;
+    tick(4);
+    expect(result.current.type).toBe("active");
+    const loud = result.current as { type: "active"; level: number };
+    expect(loud.level).toBeGreaterThan(0.3);
+
+    // ...and stops. The level eases back down rather than snapping to zero.
+    amplitude = 0;
+    tick(30);
+    const quiet = result.current as { type: "active"; level: number };
+    expect(quiet.level).toBeLessThan(loud.level);
+  });
+
+  test("metering resumes a capture the browser starts suspended", async () => {
+    const { stream } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+
+    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    await waitFor(() => expect(result.current.type).toBe("active"));
+
+    // A suspended context reports silence however loud the microphone is,
+    // which is what Firefox hands us when the page has no user activation.
+    expect(resumed).toBe(1);
+  });
+
+  test("level indicator stays idle for a silent microphone", async () => {
+    const { stream } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+
+    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    await waitFor(() => expect(result.current.type).toBe("active"));
+    tick(10);
+    expect(result.current).toEqual({ type: "active", level: 0 });
+  });
+
+  test("capture is re-pointed when the microphone changes", async () => {
+    const first = fakeStream();
+    const second = fakeStream();
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first.stream)
+      .mockResolvedValueOnce(second.stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useMicrophoneLevel(id, true),
+      { initialProps: { id: "mic-1" } },
+    );
+    await waitFor(() => expect(result.current.type).toBe("active"));
+    expect(getUserMedia).toHaveBeenLastCalledWith({
+      audio: { deviceId: { exact: "mic-1" } },
+    });
+
+    rerender({ id: "mic-2" });
+    await waitFor(() =>
+      expect(getUserMedia).toHaveBeenLastCalledWith({
+        audio: { deviceId: { exact: "mic-2" } },
+      }),
+    );
+    // The capture of the microphone we left must not survive the switch.
+    expect(first.stop).toHaveBeenCalled();
+    expect(second.stop).not.toHaveBeenCalled();
+  });
+
+  test("menu capture is released when closed during a device switch", async () => {
+    const { stream, stop } = fakeStream();
+    let resolveCapture: (s: MediaStream) => void = () => {};
+    const capture = new Promise<MediaStream>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const getUserMedia = vi.fn().mockReturnValue(capture);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useMicrophoneLevel("mic-1", on),
+      { initialProps: { on: true } },
+    );
+
+    // The menu closes before the microphone finishes opening.
+    rerender({ on: false });
+    await act(async () => {
+      resolveCapture(stream);
+      await capture;
+    });
+
+    expect(stop).toHaveBeenCalled();
+    expect(result.current).toEqual({ type: "inactive" });
+    expect(frames).toHaveLength(0);
+  });
+
+  test("microphone capture is closed when metering stops", async () => {
+    const { stream, stop } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useMicrophoneLevel("mic-1", on),
+      { initialProps: { on: true } },
+    );
+    await waitFor(() => expect(result.current.type).toBe("active"));
+
+    rerender({ on: false });
+    expect(stop).toHaveBeenCalled();
+    expect(closed).toBe(1);
+    expect(result.current).toEqual({ type: "inactive" });
+  });
+
+  test("a denied microphone is distinguished from one that cannot be opened", async () => {
+    const denied = Object.assign(new Error("no"), { name: "NotAllowedError" });
+    const busy = Object.assign(new Error("busy"), { name: "NotReadableError" });
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce(denied)
+      .mockRejectedValueOnce(busy);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useMicrophoneLevel(id, true),
+      { initialProps: { id: "mic-1" } },
+    );
+    await waitFor(() => expect(result.current).toEqual({ type: "denied" }));
+
+    rerender({ id: "mic-2" });
+    await waitFor(() =>
+      expect(result.current).toEqual({ type: "unavailable" }),
+    );
+  });
+
+  test("no capture is taken while metering is disabled", () => {
+    const getUserMedia = vi.fn();
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const { result } = renderHook(() => useMicrophoneLevel("mic-1", false));
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ type: "inactive" });
+  });
+
+  let amplitude = 0;
+  let frames: (() => void)[] = [];
+  let closed = 0;
+  let resumed = 0;
+
+  beforeEach(() => {
+    amplitude = 0;
+    frames = [];
+    closed = 0;
+    resumed = 0;
+
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {
+      frames = [];
+    });
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        public createAnalyser(): unknown {
+          return {
+            fftSize: 1024,
+            getFloatTimeDomainData: (out: Float32Array): void => {
+              out.fill(amplitude);
+            },
+          };
+        }
+        public createMediaStreamSource(): { connect: () => void } {
+          return { connect: (): void => {} };
+        }
+        public async resume(): Promise<void> {
+          resumed++;
+          await Promise.resolve();
+        }
+        public async close(): Promise<void> {
+          closed++;
+          await Promise.resolve();
+        }
+      },
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** A microphone that reports a constant amplitude on every sample. */
+  function fakeStream(): {
+    stream: MediaStream;
+    stop: ReturnType<typeof vi.fn>;
+  } {
+    const stop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop }],
+    } as unknown as MediaStream;
+    return { stream, stop };
+  }
+
+  /** Runs one animation frame, if the hook has asked for one. */
+  function tick(times = 1): void {
+    for (let i = 0; i < times; i++) {
+      const pending = frames;
+      frames = [];
+      act(() => {
+        pending.forEach((f) => f());
+      });
+    }
+  }
+});

--- a/src/components/useMicrophoneLevel.test.tsx
+++ b/src/components/useMicrophoneLevel.test.tsx
@@ -227,6 +227,17 @@ describe("useMicrophoneLevel", () => {
     expect(result.current).toEqual({ type: "unavailable" });
   });
 
+  test("a missing microphone is reported as absent, not as silence", () => {
+    const getUserMedia = vi.fn();
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const { result } = renderHook(() =>
+      useMicrophoneLevel(undefined, true, STEPS),
+    );
+    expect(result.current).toEqual({ type: "absent" });
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
   test("no capture is taken while metering is disabled", () => {
     const getUserMedia = vi.fn();
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });

--- a/src/components/useMicrophoneLevel.test.tsx
+++ b/src/components/useMicrophoneLevel.test.tsx
@@ -227,6 +227,33 @@ describe("useMicrophoneLevel", () => {
     expect(result.current).toEqual({ type: "unavailable" });
   });
 
+  test("a capture is released when the audio graph fails to build", async () => {
+    const { stream, stop } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    // Whatever the browser does after the microphone is already open.
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        public constructor() {
+          throw new Error("no audio backend");
+        }
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", true, STEPS),
+    );
+    await waitFor(() =>
+      expect(result.current).toEqual({ type: "unavailable" }),
+    );
+
+    // Otherwise the microphone stays open, and its in-use light on, behind a
+    // meter that says it is unavailable.
+    expect(stop).toHaveBeenCalled();
+  });
+
   test("a missing microphone is reported as absent, not as silence", () => {
     const getUserMedia = vi.fn();
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });

--- a/src/components/useMicrophoneLevel.test.tsx
+++ b/src/components/useMicrophoneLevel.test.tsx
@@ -6,9 +6,16 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 
-import { useMicrophoneLevel } from "./useMicrophoneLevel";
+import {
+  useMicrophoneLevel,
+  type MicrophoneLevelState,
+} from "./useMicrophoneLevel";
+
+/** However many levels a caller says it can draw; the meter asks for 18. */
+const STEPS = 18;
 
 describe("useMicrophoneLevel", () => {
   test("level indicator follows the microphone signal level", async () => {
@@ -16,7 +23,9 @@ describe("useMicrophoneLevel", () => {
     const getUserMedia = vi.fn().mockResolvedValue(stream);
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
-    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", true, STEPS),
+    );
     await waitFor(() => expect(result.current.type).toBe("active"));
     expect(result.current).toEqual({ type: "active", level: 0 });
 
@@ -40,12 +49,65 @@ describe("useMicrophoneLevel", () => {
       mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
     });
 
-    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", true, STEPS),
+    );
     await waitFor(() => expect(result.current.type).toBe("active"));
 
     // A suspended context reports silence however loud the microphone is,
     // which is what Firefox hands us when the page has no user activation.
     expect(resumed).toBe(1);
+  });
+
+  test("a silent microphone re-renders nothing", async () => {
+    const { stream } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    const probe = renderProbe();
+    await waitFor(() => expect(probe.state().type).toBe("active"));
+
+    // The capture keeps sampling, but a frame that would draw the same bars
+    // must not re-render the menu the meter sits in.
+    const before = probe.renders();
+    tick(30);
+    expect(probe.renders() - before).toBeLessThanOrEqual(1);
+  });
+
+  test("a steady tone re-renders only until the level settles", async () => {
+    const { stream } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    const probe = renderProbe();
+    await waitFor(() => expect(probe.state().type).toBe("active"));
+
+    amplitude = 0.2;
+    tick(20);
+    expect(probe.state()).toEqual({
+      type: "active",
+      level: expect.any(Number),
+    });
+
+    const before = probe.renders();
+    tick(20);
+    expect(probe.renders() - before).toBeLessThanOrEqual(1);
+  });
+
+  test("the reported level is one the meter can draw", async () => {
+    const { stream } = fakeStream();
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", true, STEPS),
+    );
+    await waitFor(() => expect(result.current.type).toBe("active"));
+
+    amplitude = 0.2;
+    tick(6);
+    const { level } = result.current as { level: number };
+    expect(level * STEPS).toBeCloseTo(Math.round(level * STEPS), 9);
   });
 
   test("level indicator stays idle for a silent microphone", async () => {
@@ -54,7 +116,9 @@ describe("useMicrophoneLevel", () => {
       mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
     });
 
-    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", true, STEPS),
+    );
     await waitFor(() => expect(result.current.type).toBe("active"));
     tick(10);
     expect(result.current).toEqual({ type: "active", level: 0 });
@@ -70,7 +134,7 @@ describe("useMicrophoneLevel", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
     const { result, rerender } = renderHook(
-      ({ id }: { id: string }) => useMicrophoneLevel(id, true),
+      ({ id }: { id: string }) => useMicrophoneLevel(id, true, STEPS),
       { initialProps: { id: "mic-1" } },
     );
     await waitFor(() => expect(result.current.type).toBe("active"));
@@ -99,7 +163,7 @@ describe("useMicrophoneLevel", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
     const { result, rerender } = renderHook(
-      ({ on }: { on: boolean }) => useMicrophoneLevel("mic-1", on),
+      ({ on }: { on: boolean }) => useMicrophoneLevel("mic-1", on, STEPS),
       { initialProps: { on: true } },
     );
 
@@ -122,7 +186,7 @@ describe("useMicrophoneLevel", () => {
     });
 
     const { result, rerender } = renderHook(
-      ({ on }: { on: boolean }) => useMicrophoneLevel("mic-1", on),
+      ({ on }: { on: boolean }) => useMicrophoneLevel("mic-1", on, STEPS),
       { initialProps: { on: true } },
     );
     await waitFor(() => expect(result.current.type).toBe("active"));
@@ -143,7 +207,7 @@ describe("useMicrophoneLevel", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
     const { result, rerender } = renderHook(
-      ({ id }: { id: string }) => useMicrophoneLevel(id, true),
+      ({ id }: { id: string }) => useMicrophoneLevel(id, true, STEPS),
       { initialProps: { id: "mic-1" } },
     );
     await waitFor(() => expect(result.current).toEqual({ type: "denied" }));
@@ -157,7 +221,9 @@ describe("useMicrophoneLevel", () => {
   test("level indicator is unavailable where the page has no media devices", () => {
     vi.stubGlobal("navigator", {});
 
-    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", true, STEPS),
+    );
     expect(result.current).toEqual({ type: "unavailable" });
   });
 
@@ -165,7 +231,9 @@ describe("useMicrophoneLevel", () => {
     const getUserMedia = vi.fn();
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
 
-    const { result } = renderHook(() => useMicrophoneLevel("mic-1", false));
+    const { result } = renderHook(() =>
+      useMicrophoneLevel("mic-1", false, STEPS),
+    );
     expect(getUserMedia).not.toHaveBeenCalled();
     expect(result.current).toEqual({ type: "inactive" });
   });
@@ -226,6 +294,30 @@ describe("useMicrophoneLevel", () => {
       getTracks: () => [{ stop }],
     } as unknown as MediaStream;
     return { stream, stop };
+  }
+
+  /**
+   * Renders a component around the hook and counts how often it renders, which
+   * is what the menu around the meter would pay on every animation frame.
+   */
+  function renderProbe(): {
+    renders: () => number;
+    state: () => MicrophoneLevelState;
+  } {
+    let renders = 0;
+    let state: MicrophoneLevelState = { type: "inactive" };
+    function Probe(): null {
+      const current = useMicrophoneLevel("mic-1", true, STEPS);
+      // An effect with no dependencies runs once per commit, so a frame
+      // React bails out of is not counted.
+      useEffect(() => {
+        renders++;
+        state = current;
+      });
+      return null;
+    }
+    render(<Probe />);
+    return { renders: () => renders, state: () => state };
   }
 
   /** Runs one animation frame, if the hook has asked for one. */

--- a/src/components/useMicrophoneLevel.test.tsx
+++ b/src/components/useMicrophoneLevel.test.tsx
@@ -154,6 +154,13 @@ describe("useMicrophoneLevel", () => {
     );
   });
 
+  test("level indicator is unavailable where the page has no media devices", () => {
+    vi.stubGlobal("navigator", {});
+
+    const { result } = renderHook(() => useMicrophoneLevel("mic-1", true));
+    expect(result.current).toEqual({ type: "unavailable" });
+  });
+
   test("no capture is taken while metering is disabled", () => {
     const getUserMedia = vi.fn();
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });

--- a/src/components/useMicrophoneLevel.ts
+++ b/src/components/useMicrophoneLevel.ts
@@ -25,6 +25,7 @@ export type MicrophoneLevelState =
 
 /** Signal at or below this many dBFS reads as silence. */
 const FLOOR_DB = -60;
+
 /**
  * Smoothing applied to the displayed level. Rises are followed almost
  * immediately so speech registers at once; falls are eased so the bars do not
@@ -43,10 +44,13 @@ const RELEASE = 0.12;
  *
  * @param deviceId - The microphone to observe, or undefined if none is selected.
  * @param enabled - Whether to hold a capture at all.
+ * @param steps - How many levels the caller can tell apart. The level is
+ *   rounded to one of them, and movement within a step reports nothing new.
  */
 export function useMicrophoneLevel(
   deviceId: string | undefined,
   enabled: boolean,
+  steps: number,
 ): MicrophoneLevelState {
   const [state, setState] = useState<MicrophoneLevelState>({
     type: "inactive",
@@ -109,7 +113,16 @@ export function useMicrophoneLevel(
           const level = amplitudeToLevel(rms(samples));
           smoothed +=
             (level - smoothed) * (level > smoothed ? ATTACK : RELEASE);
-          setState({ type: "active", level: smoothed });
+          // Keep the last value when the level has not moved a whole step:
+          // a frame that would redraw the same picture must not re-render
+          // anything. Silence therefore costs nothing at all, since the level
+          // rests at zero.
+          const stepped = Math.round(smoothed * steps) / steps;
+          setState((previous) =>
+            previous.type === "active" && previous.level === stepped
+              ? previous
+              : { type: "active", level: stepped },
+          );
           frame = requestAnimationFrame(tick);
         };
         setState({ type: "active", level: 0 });
@@ -124,7 +137,7 @@ export function useMicrophoneLevel(
       });
 
     return dispose;
-  }, [deviceId, enabled]);
+  }, [deviceId, enabled, steps]);
 
   return state;
 }

--- a/src/components/useMicrophoneLevel.ts
+++ b/src/components/useMicrophoneLevel.ts
@@ -57,6 +57,11 @@ export function useMicrophoneLevel(
       setState({ type: "inactive" });
       return;
     }
+    // Insecure contexts have no media devices at all; nothing can be metered.
+    if (!("mediaDevices" in navigator)) {
+      setState({ type: "unavailable" });
+      return;
+    }
 
     // Guards every asynchronous continuation below: the effect can be cleaned
     // up while getUserMedia is still in flight, and the stream it eventually

--- a/src/components/useMicrophoneLevel.ts
+++ b/src/components/useMicrophoneLevel.ts
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { useEffect, useState } from "react";
+import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
+
+/**
+ * The state of the microphone level indicator.
+ *
+ * `inactive` is the resting state: nothing is being captured, because nothing
+ * has asked for a level yet. `active` means we hold a capture and `level` is
+ * the current signal level in the range 0..1. `denied` and `unavailable` are
+ * the two failure modes we distinguish, because they need different UI: the
+ * first is recoverable by the user, the second is not.
+ */
+export type MicrophoneLevelState =
+  | { type: "inactive" }
+  | { type: "active"; level: number }
+  | { type: "denied" }
+  | { type: "unavailable" };
+
+/** Signal at or below this many dBFS reads as silence. */
+const FLOOR_DB = -60;
+/**
+ * Smoothing applied to the displayed level. Rises are followed almost
+ * immediately so speech registers at once; falls are eased so the bars do not
+ * flicker between syllables.
+ */
+const ATTACK = 0.5;
+const RELEASE = 0.12;
+
+/**
+ * Observes the signal level of a microphone, for as long as `enabled` holds.
+ *
+ * The capture is owned by this hook and is torn down whenever `enabled` goes
+ * false, the device changes, or the component unmounts, including when any of
+ * those happen while the capture is still being acquired. Nothing outlives the
+ * caller.
+ *
+ * @param deviceId - The microphone to observe, or undefined if none is selected.
+ * @param enabled - Whether to hold a capture at all.
+ */
+export function useMicrophoneLevel(
+  deviceId: string | undefined,
+  enabled: boolean,
+): MicrophoneLevelState {
+  const [state, setState] = useState<MicrophoneLevelState>({
+    type: "inactive",
+  });
+
+  useEffect(() => {
+    if (!enabled || deviceId === undefined) {
+      setState({ type: "inactive" });
+      return;
+    }
+
+    // Guards every asynchronous continuation below: the effect can be cleaned
+    // up while getUserMedia is still in flight, and the stream it eventually
+    // resolves with must be stopped rather than left running.
+    let disposed = false;
+    let stream: MediaStream | undefined;
+    let context: AudioContext | undefined;
+    let frame: number | undefined;
+
+    const dispose = (): void => {
+      disposed = true;
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      stream?.getTracks().forEach((t) => t.stop());
+      // close() rejects if the context is already closed, which is possible if
+      // the browser tore it down with the page.
+      context?.close().catch(() => {});
+      stream = undefined;
+      context = undefined;
+      frame = undefined;
+    };
+
+    navigator.mediaDevices
+      .getUserMedia({ audio: { deviceId: { exact: deviceId } } })
+      .then((acquired) => {
+        if (disposed) {
+          acquired.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        stream = acquired;
+        context = new AudioContext();
+        // Firefox starts a context suspended unless the page has user
+        // activation, and a suspended context feeds the analyser silence
+        // rather than the microphone. Resuming one that already runs is a
+        // no-op.
+        void context.resume().catch(() => {});
+        const analyser = context.createAnalyser();
+        analyser.fftSize = 1024;
+        context.createMediaStreamSource(acquired).connect(analyser);
+        const samples = new Float32Array(analyser.fftSize);
+
+        let smoothed = 0;
+        const tick = (): void => {
+          if (disposed) return;
+          analyser.getFloatTimeDomainData(samples);
+          const level = amplitudeToLevel(rms(samples));
+          smoothed +=
+            (level - smoothed) * (level > smoothed ? ATTACK : RELEASE);
+          setState({ type: "active", level: smoothed });
+          frame = requestAnimationFrame(tick);
+        };
+        setState({ type: "active", level: 0 });
+        frame = requestAnimationFrame(tick);
+      })
+      .catch((e: unknown) => {
+        if (disposed) return;
+        rootLogger
+          .getChild("[useMicrophoneLevel]")
+          .warn("Could not open microphone for level metering", e);
+        setState(classifyError(e));
+      });
+
+    return dispose;
+  }, [deviceId, enabled]);
+
+  return state;
+}
+
+/** Root mean square of a block of samples, as a linear amplitude. */
+function rms(samples: Float32Array): number {
+  let sum = 0;
+  for (const s of samples) sum += s * s;
+  return Math.sqrt(sum / samples.length);
+}
+
+/** Maps a linear amplitude onto 0..1 over a fixed dBFS window. */
+function amplitudeToLevel(amplitude: number): number {
+  if (amplitude <= 0) return 0;
+  const db = 20 * Math.log10(amplitude);
+  if (db <= FLOOR_DB) return 0;
+  return Math.min(1, db / -FLOOR_DB + 1);
+}
+
+function classifyError(e: unknown): MicrophoneLevelState {
+  const name = e instanceof Error ? e.name : "";
+  // NotAllowedError is the modern name; SecurityError is what older WebKit
+  // raises for the same situation.
+  if (name === "NotAllowedError" || name === "SecurityError")
+    return { type: "denied" };
+  return { type: "unavailable" };
+}

--- a/src/components/useMicrophoneLevel.ts
+++ b/src/components/useMicrophoneLevel.ts
@@ -82,8 +82,8 @@ export function useMicrophoneLevel(
     let context: AudioContext | undefined;
     let frame: number | undefined;
 
-    const dispose = (): void => {
-      disposed = true;
+    /** Gives back whatever has been acquired so far. */
+    const release = (): void => {
       if (frame !== undefined) cancelAnimationFrame(frame);
       stream?.getTracks().forEach((t) => t.stop());
       // close() rejects if the context is already closed, which is possible if
@@ -92,6 +92,11 @@ export function useMicrophoneLevel(
       stream = undefined;
       context = undefined;
       frame = undefined;
+    };
+
+    const dispose = (): void => {
+      disposed = true;
+      release();
     };
 
     navigator.mediaDevices
@@ -137,6 +142,11 @@ export function useMicrophoneLevel(
       })
       .catch((e: unknown) => {
         if (disposed) return;
+        // The microphone may already be open: building the audio graph can
+        // fail after getUserMedia has resolved, and the capture would then
+        // outlive its own failure, holding the microphone-in-use indicator on
+        // behind a meter that says the microphone is unavailable.
+        release();
         rootLogger
           .getChild("[useMicrophoneLevel]")
           .warn("Could not open microphone for level metering", e);

--- a/src/components/useMicrophoneLevel.ts
+++ b/src/components/useMicrophoneLevel.ts
@@ -12,13 +12,16 @@ import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
  * The state of the microphone level indicator.
  *
  * `inactive` is the resting state: nothing is being captured, because nothing
- * has asked for a level yet. `active` means we hold a capture and `level` is
- * the current signal level in the range 0..1. `denied` and `unavailable` are
- * the two failure modes we distinguish, because they need different UI: the
- * first is recoverable by the user, the second is not.
+ * has asked for a level yet. `absent` means there is no microphone to capture
+ * from, which is not the same as one that hears nothing. `active` means we
+ * hold a capture and `level` is the current signal level in the range 0..1.
+ * `denied` and `unavailable` are the two failure modes we distinguish, because
+ * they need different UI: the first is recoverable by the user, the second is
+ * not.
  */
 export type MicrophoneLevelState =
   | { type: "inactive" }
+  | { type: "absent" }
   | { type: "active"; level: number }
   | { type: "denied" }
   | { type: "unavailable" };
@@ -57,8 +60,12 @@ export function useMicrophoneLevel(
   });
 
   useEffect(() => {
-    if (!enabled || deviceId === undefined) {
+    if (!enabled) {
       setState({ type: "inactive" });
+      return;
+    }
+    if (deviceId === undefined) {
+      setState({ type: "absent" });
       return;
     }
     // Insecure contexts have no media devices at all; nothing can be metered.

--- a/src/room/__snapshots__/InCallView.test.tsx.snap
+++ b/src/room/__snapshots__/InCallView.test.tsx.snap
@@ -328,36 +328,67 @@ exports[`InCallView > rendering > renders 1`] = `
             />
           </svg>
         </button>
-        <button
-          aria-busy="false"
-          aria-checked="false"
-          aria-disabled="true"
-          aria-labelledby="_r_l_"
-          class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
-          data-kind="primary"
-          data-size="lg"
-          data-testid="incall_mute"
-          role="switch"
-          tabindex="0"
+        <div
+          class="_container_e649de"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-busy="false"
+            aria-checked="false"
+            aria-disabled="true"
+            aria-labelledby="_r_l_"
+            class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="primary"
+            data-size="lg"
+            data-testid="incall_mute"
+            role="switch"
+            tabindex="0"
           >
-            <path
-              d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
+              />
+            </svg>
+          </button>
+          <button
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-haspopup="menu"
+            aria-label="Microphone"
+            class="_button_1nw83_8 _menuButton_e649de _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="tertiary"
+            data-size="lg"
+            data-state="closed"
+            id="radix-_r_q_"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 14.95q-.2 0-.375-.062a.9.9 0 0 1-.325-.213l-4.6-4.6a.95.95 0 0 1-.275-.7q0-.425.275-.7a.95.95 0 0 1 .7-.275q.425 0 .7.275l3.9 3.9 3.9-3.9a.95.95 0 0 1 .7-.275q.425 0 .7.275a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7l-4.6 4.6q-.15.15-.325.212a1.1 1.1 0 0 1-.375.063"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           aria-busy="false"
           aria-checked="false"
           aria-disabled="true"
-          aria-labelledby="_r_q_"
+          aria-labelledby="_r_s_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="primary"
           data-size="lg"
@@ -382,7 +413,7 @@ exports[`InCallView > rendering > renders 1`] = `
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="_r_v_"
+          aria-labelledby="_r_11_"
           class="_button_1nw83_8 _raiseHand_20b7b4 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="secondary"
           data-size="lg"
@@ -405,7 +436,7 @@ exports[`InCallView > rendering > renders 1`] = `
           </svg>
         </button>
         <button
-          aria-labelledby="_r_17_"
+          aria-labelledby="_r_19_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53 _destructive_1nw83_110"
           data-kind="primary"
           data-size="lg"
@@ -433,8 +464,8 @@ exports[`InCallView > rendering > renders 1`] = `
         data-size="lg"
       >
         <input
-          aria-labelledby="_r_1d_"
-          name="_r_1c_"
+          aria-labelledby="_r_1f_"
+          name="_r_1e_"
           type="radio"
           value="spotlight"
         />
@@ -453,9 +484,9 @@ exports[`InCallView > rendering > renders 1`] = `
           />
         </svg>
         <input
-          aria-labelledby="_r_1i_"
+          aria-labelledby="_r_1k_"
           checked=""
-          name="_r_1c_"
+          name="_r_1e_"
           type="radio"
           value="grid"
         />

--- a/src/room/__snapshots__/LobbyView.test.tsx.snap
+++ b/src/room/__snapshots__/LobbyView.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`LobbyView > renders with AppBar android 1`] = `
   >
     <header>
       <button
-        aria-labelledby="_r_36_"
+        aria-labelledby="_r_3c_"
         class="_icon-button_1215g_8 _primaryButton_221541"
         data-kind="primary"
         role="button"
@@ -102,7 +102,7 @@ exports[`LobbyView > renders with AppBar android 1`] = `
         class="_settingsLogoContainer_20b7b4"
       >
         <button
-          aria-labelledby="_r_3c_"
+          aria-labelledby="_r_3i_"
           class="_icon-button_1215g_8 _settingsOnlyShowWide_20b7b4"
           data-kind="secondary"
           data-testid="settings-bottom-left"
@@ -133,7 +133,7 @@ exports[`LobbyView > renders with AppBar android 1`] = `
         class="_buttons_20b7b4"
       >
         <button
-          aria-labelledby="_r_3h_"
+          aria-labelledby="_r_3n_"
           class="_button_1nw83_8 _settingsOnlyShowNarrow_20b7b4 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="secondary"
           data-size="lg"
@@ -154,36 +154,67 @@ exports[`LobbyView > renders with AppBar android 1`] = `
             />
           </svg>
         </button>
-        <button
-          aria-busy="false"
-          aria-checked="false"
-          aria-disabled="true"
-          aria-labelledby="_r_3m_"
-          class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
-          data-kind="primary"
-          data-size="lg"
-          data-testid="incall_mute"
-          role="switch"
-          tabindex="0"
+        <div
+          class="_container_e649de"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-busy="false"
+            aria-checked="false"
+            aria-disabled="true"
+            aria-labelledby="_r_3s_"
+            class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="primary"
+            data-size="lg"
+            data-testid="incall_mute"
+            role="switch"
+            tabindex="0"
           >
-            <path
-              d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
+              />
+            </svg>
+          </button>
+          <button
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-haspopup="menu"
+            aria-label="Microphone"
+            class="_button_1nw83_8 _menuButton_e649de _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="tertiary"
+            data-size="lg"
+            data-state="closed"
+            id="radix-_r_41_"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 14.95q-.2 0-.375-.062a.9.9 0 0 1-.325-.213l-4.6-4.6a.95.95 0 0 1-.275-.7q0-.425.275-.7a.95.95 0 0 1 .7-.275q.425 0 .7.275l3.9 3.9 3.9-3.9a.95.95 0 0 1 .7-.275q.425 0 .7.275a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7l-4.6 4.6q-.15.15-.325.212a1.1 1.1 0 0 1-.375.063"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           aria-busy="false"
           aria-checked="false"
           aria-disabled="true"
-          aria-labelledby="_r_3r_"
+          aria-labelledby="_r_43_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="primary"
           data-size="lg"
@@ -205,7 +236,7 @@ exports[`LobbyView > renders with AppBar android 1`] = `
           </svg>
         </button>
         <button
-          aria-labelledby="_r_40_"
+          aria-labelledby="_r_48_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53 _destructive_1nw83_110"
           data-kind="primary"
           data-size="lg"
@@ -239,7 +270,7 @@ exports[`LobbyView > renders with AppBar ios 1`] = `
   >
     <header>
       <button
-        aria-labelledby="_r_4a_"
+        aria-labelledby="_r_4i_"
         class="_icon-button_1215g_8 _primaryButton_221541"
         data-kind="primary"
         role="button"
@@ -334,7 +365,7 @@ exports[`LobbyView > renders with AppBar ios 1`] = `
         class="_settingsLogoContainer_20b7b4"
       >
         <button
-          aria-labelledby="_r_4g_"
+          aria-labelledby="_r_4o_"
           class="_icon-button_1215g_8 _settingsOnlyShowWide_20b7b4"
           data-kind="secondary"
           data-testid="settings-bottom-left"
@@ -365,7 +396,7 @@ exports[`LobbyView > renders with AppBar ios 1`] = `
         class="_buttons_20b7b4"
       >
         <button
-          aria-labelledby="_r_4l_"
+          aria-labelledby="_r_4t_"
           class="_button_1nw83_8 _settingsOnlyShowNarrow_20b7b4 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="secondary"
           data-size="lg"
@@ -386,36 +417,67 @@ exports[`LobbyView > renders with AppBar ios 1`] = `
             />
           </svg>
         </button>
-        <button
-          aria-busy="false"
-          aria-checked="false"
-          aria-disabled="true"
-          aria-labelledby="_r_4q_"
-          class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
-          data-kind="primary"
-          data-size="lg"
-          data-testid="incall_mute"
-          role="switch"
-          tabindex="0"
+        <div
+          class="_container_e649de"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-busy="false"
+            aria-checked="false"
+            aria-disabled="true"
+            aria-labelledby="_r_52_"
+            class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="primary"
+            data-size="lg"
+            data-testid="incall_mute"
+            role="switch"
+            tabindex="0"
           >
-            <path
-              d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
+              />
+            </svg>
+          </button>
+          <button
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-haspopup="menu"
+            aria-label="Microphone"
+            class="_button_1nw83_8 _menuButton_e649de _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="tertiary"
+            data-size="lg"
+            data-state="closed"
+            id="radix-_r_57_"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 14.95q-.2 0-.375-.062a.9.9 0 0 1-.325-.213l-4.6-4.6a.95.95 0 0 1-.275-.7q0-.425.275-.7a.95.95 0 0 1 .7-.275q.425 0 .7.275l3.9 3.9 3.9-3.9a.95.95 0 0 1 .7-.275q.425 0 .7.275a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7l-4.6 4.6q-.15.15-.325.212a1.1 1.1 0 0 1-.375.063"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           aria-busy="false"
           aria-checked="false"
           aria-disabled="true"
-          aria-labelledby="_r_4v_"
+          aria-labelledby="_r_59_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="primary"
           data-size="lg"
@@ -437,7 +499,7 @@ exports[`LobbyView > renders with AppBar ios 1`] = `
           </svg>
         </button>
         <button
-          aria-labelledby="_r_54_"
+          aria-labelledby="_r_5e_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53 _destructive_1nw83_110"
           data-kind="primary"
           data-size="lg"
@@ -768,36 +830,67 @@ exports[`LobbyView > renders with header and participant count 1`] = `
             />
           </svg>
         </button>
-        <button
-          aria-busy="false"
-          aria-checked="false"
-          aria-disabled="true"
-          aria-labelledby="_r_g_"
-          class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
-          data-kind="primary"
-          data-size="lg"
-          data-testid="incall_mute"
-          role="switch"
-          tabindex="0"
+        <div
+          class="_container_e649de"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-busy="false"
+            aria-checked="false"
+            aria-disabled="true"
+            aria-labelledby="_r_g_"
+            class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="primary"
+            data-size="lg"
+            data-testid="incall_mute"
+            role="switch"
+            tabindex="0"
           >
-            <path
-              d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 8v-.006l6.831 6.832-.002.002 1.414 1.415.003-.003 1.414 1.414-.003.003L20.5 20.5a1 1 0 0 1-1.414 1.414l-3.022-3.022A7.95 7.95 0 0 1 13 19.938V21a1 1 0 0 1-2 0v-1.062A8 8 0 0 1 4 12a1 1 0 1 1 2 0 6 6 0 0 0 8.587 5.415l-1.55-1.55A4.005 4.005 0 0 1 8 12v-1.172L2.086 4.914A1 1 0 0 1 3.5 3.5zm9.417 6.583 1.478 1.477A7.96 7.96 0 0 0 20 12a1 1 0 0 0-2 0c0 .925-.21 1.8-.583 2.583M8.073 5.238l7.793 7.793q.132-.495.134-1.031V6a4 4 0 0 0-7.927-.762"
+              />
+            </svg>
+          </button>
+          <button
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-haspopup="menu"
+            aria-label="Microphone"
+            class="_button_1nw83_8 _menuButton_e649de _has-icon_1nw83_60 _icon-only_1nw83_53"
+            data-kind="tertiary"
+            data-size="lg"
+            data-state="closed"
+            id="radix-_r_l_"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 14.95q-.2 0-.375-.062a.9.9 0 0 1-.325-.213l-4.6-4.6a.95.95 0 0 1-.275-.7q0-.425.275-.7a.95.95 0 0 1 .7-.275q.425 0 .7.275l3.9 3.9 3.9-3.9a.95.95 0 0 1 .7-.275q.425 0 .7.275a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7l-4.6 4.6q-.15.15-.325.212a1.1 1.1 0 0 1-.375.063"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           aria-busy="false"
           aria-checked="false"
           aria-disabled="true"
-          aria-labelledby="_r_l_"
+          aria-labelledby="_r_n_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53"
           data-kind="primary"
           data-size="lg"
@@ -819,7 +912,7 @@ exports[`LobbyView > renders with header and participant count 1`] = `
           </svg>
         </button>
         <button
-          aria-labelledby="_r_q_"
+          aria-labelledby="_r_s_"
           class="_button_1nw83_8 _has-icon_1nw83_60 _icon-only_1nw83_53 _destructive_1nw83_110"
           data-kind="primary"
           data-size="lg"


### PR DESCRIPTION
## Content

The chevron beside the microphone button opens an **Audio controls** menu with three groups: the microphones with a live level meter, the audio outputs, and the sound-effect volume. One commit per slice of the spec, each building and passing the unit suite on its own:

1. **Speaker group in the menu.** Outputs are listed below a separator, the active one marked; selecting switches output and keeps the menu open. With one output or none, as on Safari, the group still names the output in use as a non-selectable row. The outputs come from the same `MediaDevices` helper as the device lists, gated like them: desktop and not PiP during a call, ungated before joining.
2. **Level meter and capture hook.** `useMicrophoneLevel` holds a capture of the selected microphone only while enabled and tears it down on disable, device change or unmount, including mid-acquisition. `AudioLevelMeter` renders the level as bars, focusable and announcing its state to a screen reader only while focused; a denied permission shows a hint, an unopenable microphone a greyed-out meter.
3. **Meter in the menu.** Capture starts when the menu opens and stops when it closes, muted or not; the meter follows the selected microphone and sits at the foot of the microphone group. Keyboard focus gets a border, pointer hover a background only.
4. **Sound-effect volume and scrolling.** A slider reading and writing the same setting as the one in Settings, so the next effect plays at the new level. The menu is bounded to the height Radix reports and only the device lists scroll; heading and slider stay put. Every control is reachable by keyboard: Radix swallows Tab inside menus, so the audio menu keeps Tab from it and lets the browser move focus from the device rows to the meter and the slider.
5. **Surface coverage.** The checks that hold the menu where it belongs: offered before joining on desktop, Android and iOS, and no chevron at all once a call starts on mobile.

Telling pointer use from keyboard use is six lines of local state rather than anything reused, because there is nothing to reuse: Compound exports no modality helper, the repo has no react-aria or focus-visible polyfill, and Radix's `data-highlighted` marks both modalities alike. A CSS-only `:focus-visible:not(:hover)` was rejected: it hides the border under the cursor but still leaves keyboard users with no border at all in Firefox, which never calls a programmatic focus keyboard-driven. The problem belongs to Compound's `Menu`, which focuses items as the pointer moves, and would be better solved there.

No new shared component beyond `AudioLevelMeter`: nothing in Compound or the repo renders a level, and it is reused nowhere else yet. The speaker rows are Compound `MenuItem`s; the read-only row is a plain row styled like one because a disabled `MenuItem` would read as a broken control rather than as information. The slider is the shared `Slider`.

## Motivation and context

Spec: `FEATURES_SPEC/2026-09_Audio_Quick_Menu.md` (status `implement`). One PR by owner decision, recorded in the spec's drift log. Acceptance criteria and their checks:

| AC | Check | Result |
| --- | --- | --- |
| AC1 [FR-001] | `pnpm vitest run --project=unit -t "audio menu is headed Audio controls"` | CI |
| AC2 [FR-002] | `-t "audio menu switches microphone and stays open"` | CI |
| AC3 [FR-003] | `-t "audio menu switches audio output and stays open"` | CI |
| AC4 [FR-004] | `-t "audio menu separates microphone speaker and sound effects groups"` | CI |
| AC5 [FR-005] | `-t "audio menu shows single audio output as non-selectable"` | CI |
| AC6 [FR-005] | manual, Safari: join a call, open the microphone chevron, confirm the speaker group names the output in use and no row responds to a click | _reviewer_ |
| AC7 [FR-006] | `-t "audio output selection is shared between menu and settings"` | CI |
| AC8 [FR-007] | `-t "level indicator follows the microphone signal level"` | CI |
| AC9 [FR-008] | `-t "level indicator responds while muted"` | CI |
| AC10 [FR-009] | `-t "audio menu starts capture on open and stops on close"` | CI |
| AC11 [internal] | `-t "menu capture is released when closed during a device switch"` | CI |
| AC12 [FR-010] | `-t "level indicator follows a microphone change"` | CI |
| AC13 [FR-011] | `-t "level indicator stays idle for a silent microphone"` | CI |
| AC14 [FR-018] | `-t "audio menu hints when microphone permission is denied"` | CI |
| AC15 [D7] | `-t "level indicator greys out when the microphone is unavailable"` | CI |
| AC16 [FR-012] | `-t "sound effects volume from the menu applies to the next effect"` | CI |
| AC17 [FR-013] | `-t "sound effects volume is shared between menu and settings"` | CI |
| AC18 [FR-014] | `-t "audio menu is present pre-join on every platform"` | CI |
| AC19 [FR-015] | `pnpm test:playwright --project=mobile -g "no audio menu during a call on mobile"` | CI |
| AC20 [FR-016] | `-t "audio menu is fully operable from the keyboard"` | CI |
| AC21 [FR-017] | manual, VoiceOver: open the menu, tab to the level indicator, speak, confirm the announced state changes with the signal | _reviewer_ |
| AC22 [D11] | `pnpm vitest run --project=storybook -t "With Many Devices"` | CI |
| AC23 [D12] | `-t "level indicator stays with the microphone list rather than the speakers"` | CI |
| AC24 [D13] | `pnpm test:playwright --project=chromium --project=firefox -g "the focus border follows the keyboard and not the pointer"` | CI |
| AC25 [SC-001] | `pnpm test:playwright --project=chromium -g "audio menu leaves participants visible while switching output"` | CI |
| AC26 [SC-002] | `pnpm test:playwright --project=chromium --project=firefox -g "level indicator moves with microphone input"` | CI, Chromium; skipped on Firefox (see below) |
| AC27 [SC-003] | `pnpm test:playwright --project=chromium --project=firefox -g "audio menu is keyboard operable in a real browser"` | CI, Chromium; skipped on Firefox (see below) |

Firefox reads the meter as zero on the CI runner, which has no audio backend for it. Neither the test device nor the code is at fault: its fake stream carries a 1 kHz tone, and the same test drives the meter to 0.62 against Firefox off the runner, including against the Docker image over plain HTTP that CI serves. AC26 is therefore skipped on Firefox, a deviation from its check. AC27 is skipped there too, because headless Firefox drives Tab unreliably, as `reconnect.spec.ts` records. AC25 skips it because that stream enumerates no audio outputs, which its Chromium-only check does not ask for. All three deviations are in the spec's drift log.

While chasing that, one real defect surfaced: Firefox starts an `AudioContext` suspended, which feeds the analyser silence for a few seconds until it resumes on its own. The capture is now resumed on creation, so the meter answers while the person is still speaking, as D10 requires.

Build targets: nothing here reads the page, and no viewport unit is used. Checked standalone and, through the component harness, as a component. As a component every chevron menu, this one and the untouched camera one alike, renders outside the root element and so outside the scoped stylesheet: no background, no border, and this menu's height bound inert. That is a pre-existing consequence of Compound's `Menu` portalling to `document.body`, needs a portal container Compound does not expose, and is raised separately rather than fixed here. It is in the spec's drift log. Widget mode is an iframe with a document of its own, so the scoping does not apply there.

The first commit is the spec itself, including the drift log this implementation appended, so the claims below can be checked against it in the same diff.

This PR targets `fkwp/feature/audio_quick_menu` rather than `main`, because it builds on two documentation PRs that are in review separately: #4256 (the repo agent contract) and #4255 (the FEATURES_SPEC process). The base branch carries only those two, so this diff is the spec plus the feature. Once they land, the base rebases onto `main` and this retargets there.

## Screenshots / GIFs

Storybook: `CallFooter › With Audio Menu`, `CallFooter › With Single Audio Output`, `CallFooter › Lobby`, and the five `AudioLevelMeter` states.

|Before|After|
|-|-|
|||

## Tests

- Unit: `MediaMuteAndSwitchButton.test.tsx` (audio menu suite), `CallFooter.test.tsx` (heading, selection and volume shared with settings), `CallFooterViewModel.test.ts` (menu behaviours per platform, layout and surface), `useMicrophoneLevel.test.tsx`, `AudioLevelMeter.test.tsx`. Whole suite: 99 files, 784 passing, 9 skipped.
- Storybook: `AudioLevelMeter` (five states) and `CallFooter` (`WithAudioMenu`, `WithSingleAudioOutput`, `WithManyDevices`, lobby stories) with play functions. `WithManyDevices` measures in the browser that the heading and the slider stay on screen while the device lists scroll, which jsdom cannot.
- E2E: `playwright/audio-menu.spec.ts` (four tests), `playwright/mobile/audio-menu-mobile.spec.ts` (mobile project). The fourth test checks at a short window that the menu, its heading and its slider stay inside the viewport, which holds however many devices a browser reports; the deterministic overflow case is the Storybook story, since Chromium and Firefox invent different numbers of fake devices.
- `InCallView` and `LobbyView` snapshots updated: the microphone button now sits in the chevron container wherever the audio menu exists.
- Not measured: the CPU cost of the meter's second capture during a call (spec `## Measurements`).

## Checklist

- [ ] A linked, pre-approved issue exists for this feature or UI change.
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/main/CONTRIBUTING.md) in full.
- [ ] Pull request includes screenshots or videos for any UI changes.
- [x] Tests written for new code (and existing touched code where feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
