### PR TITLE
Always log LiveKit ICE candidates and states to the rageshake

### DIFF
--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -25,6 +25,7 @@ import {
 import {
   setLogExtension as setLKLogExtension,
   setLogLevel as setLKLogLevel,
+  LoggerNames as LKLoggerNames,
 } from "livekit-client";
 
 import { getUrlParams } from "./UrlParams";
@@ -226,6 +227,9 @@ export class Initializer {
 
     enableExtendedLivekitLogs.value$.subscribe((enabled) => {
       setLKLogLevel(enabled ? "trace" : "info");
+      // ICE candidate types and connection states are what you need to diagnose
+      // "could not establish pc connection", so always keep those in the rageshake
+      setLKLogLevel("debug", LKLoggerNames.ICE);
     });
 
     window.setLKLogLevel = setLKLogLevel;


### PR DESCRIPTION
## Content

Keep LiveKit's `livekit-ice` logger at debug level regardless of the "extended LiveKit logs" setting, so its output (each local ICE candidate with its type, ICE candidate errors, ICE connection state changes) always lands in the rageshake.

## Motivation and context

Rageshakes for "could not establish pc connection" (e.g. element-hq/element-call-rageshakes#17444) currently contain no ICE information at all, because we cap all LiveKit loggers at info unless extended logs are switched on. That makes it impossible to tell "no srflx/relay candidates gathered" (UDP and TURN blocked client-side) from "relay candidates gathered but never paired" (server-side or return-path problem) without asking the user to reproduce with chrome://webrtc-internals open. LiveKit already has a dedicated logger for exactly this, we just weren't listening to it.

## Tests

- Join a call and confirm the rageshake / console now contains `livekit-ice` lines for local candidates and `ICE connection state: ...` transitions without enabling extended LiveKit logs.

## Checklist

- [x] A linked, pre-approved issue exists for this feature or UI change. (not a feature or UI change)
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/main/CONTRIBUTING.md) in full.
- [x] Pull request includes screenshots or videos for any UI changes. (n/a)
- [x] Tests written for new code (and existing touched code where feasible). (logging config only)
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSB8Qb89KDoTNRV83dWJHa